### PR TITLE
Add search hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_39'
-            php: '8.2'
+          - mw: 'REL1_43'
+            php: '8.3'
 
     runs-on: ubuntu-latest
 

--- a/extension.json
+++ b/extension.json
@@ -36,6 +36,8 @@
 	},
 
 	"Hooks": {
+		"ShowSearchHitTitle": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onShowSearchHitTitle",
+		"SpecialSearchResultsAppend": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onSpecialSearchResultsAppend"
 	},
 
 	"config": {

--- a/extension.json
+++ b/extension.json
@@ -49,6 +49,15 @@
 	},
 
 	"ResourceModules": {
+		"ext.wikibase.facetedsearch.styles": {
+			"styles": [
+				"ext.wikibase.facetedsearch.less"
+			],
+			"targets": [
+				"mobile",
+				"desktop"
+			]
+		}
 	},
 
 	"RestRoutes": [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,1 +1,55 @@
 parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to method addHTML\(\) on an unknown class OutputPage\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/EntryPoints/WikibaseFacetedSearchHooks.php
+
+		-
+			message: '#^Call to method addModuleStyles\(\) on an unknown class OutputPage\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/EntryPoints/WikibaseFacetedSearchHooks.php
+
+		-
+			message: '#^Call to method getNamespace\(\) on an unknown class Title\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/EntryPoints/WikibaseFacetedSearchHooks.php
+
+		-
+			message: '#^Call to static method element\(\) on an unknown class Html\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/EntryPoints/WikibaseFacetedSearchHooks.php
+
+		-
+			message: '#^Constant WB_NS_ITEM not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: src/EntryPoints/WikibaseFacetedSearchHooks.php
+
+		-
+			message: '#^Parameter \$output of method ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks\:\:onSpecialSearchResultsAppend\(\) has invalid type OutputPage\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/EntryPoints/WikibaseFacetedSearchHooks.php
+
+		-
+			message: '#^Parameter \$specialSearch of method ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks\:\:onShowSearchHitTitle\(\) has invalid type SpecialSearch\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/EntryPoints/WikibaseFacetedSearchHooks.php
+
+		-
+			message: '#^Parameter \$specialSearch of method ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks\:\:onSpecialSearchResultsAppend\(\) has invalid type SpecialSearch\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/EntryPoints/WikibaseFacetedSearchHooks.php
+
+		-
+			message: '#^Parameter \$title of method ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks\:\:onShowSearchHitTitle\(\) has invalid type Title\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/EntryPoints/WikibaseFacetedSearchHooks.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,3 +9,4 @@ parameters:
 		- ../../includes
 		- ../../tests/phpunit
 		- ../../vendor
+		- ../../extensions/Wikibase

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -1,0 +1,6 @@
+@import 'mediawiki.skin.variables.less';
+
+.wikibase-faceted-search__facets {
+	border: @border-width-base @border-style-base @border-color-base;
+	padding: @spacing-100;
+}

--- a/src/EntryPoints/WikibaseFacetedSearchHooks.php
+++ b/src/EntryPoints/WikibaseFacetedSearchHooks.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\EntryPoints;
+
+use OutputPage;
+use SearchResult;
+use SpecialSearch;
+use Title;
+
+class WikibaseFacetedSearchHooks {
+
+	/**
+	 * @param string[] $terms
+	 * @param array<string, mixed> $query
+	 * @param array<string, mixed> $attributes
+	 */
+	public static function onShowSearchHitTitle(
+		Title &$title,
+		?string &$titleSnippet,
+		SearchResult $result,
+		array $terms,
+		SpecialSearch $specialSearch,
+		array &$query,
+		array &$attributes
+	): void {
+		if ( $title->getNamespace() !== WB_NS_ITEM ) {
+			return;
+		}
+
+		// TODO: get item site link and replace $title
+	}
+
+	public static function onSpecialSearchResultsAppend(
+		SpecialSearch $specialSearch,
+		OutputPage $output,
+		string $term
+	): void {
+		// TODO: generate facets from search term
+	}
+
+}

--- a/src/EntryPoints/WikibaseFacetedSearchHooks.php
+++ b/src/EntryPoints/WikibaseFacetedSearchHooks.php
@@ -38,6 +38,10 @@ class WikibaseFacetedSearchHooks {
 		string $term
 	): void {
 		// TODO: generate facets from search term
+		$output->addModuleStyles( 'ext.wikibase.facetedsearch.styles' );
+		$output->addHTML(
+			\Html::element( 'div', [ 'class' => 'wikibase-faceted-search__facets' ] )
+		);
 	}
 
 }


### PR DESCRIPTION
For #3 

Adds hooks for:
* changing search result title/link
* adding facets container

----

This does not add a hook for modifying the form part of the search page. Whether we want to do this depends on how item type selection should happen. However, if we do need to modify the form, here's what I found so far:
* [SpecialSearchProfileForm hook](https://www.mediawiki.org/wiki/Manual:Hooks/SpecialSearchProfileForm) can add HTML, but not when using the Advanced tab
* [Extension:AdvancedSearch](https://www.mediawiki.org/wiki/Extension:AdvancedSearch) builds a custom form in Javascript