### PR TITLE
Add config page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
 	],
 	"require": {
 		"php": ">=8.1",
-		"composer/installers": "^2|^1.0.1"
+		"composer/installers": "^2|^1.0.1",
+		"opis/json-schema": "^2.3.0"
 	},
 	"require-dev": {
 		"phpstan/phpstan": "^2.0.1",

--- a/example.json
+++ b/example.json
@@ -1,0 +1,3 @@
+{
+	"linkTargetSitelinkSiteId": "enwiki"
+}

--- a/extension.json
+++ b/extension.json
@@ -36,11 +36,28 @@
 	},
 
 	"Hooks": {
+		"AlternateEdit": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onAlternateEdit",
+		"BeforePageDisplay": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onBeforePageDisplay",
+		"ContentHandlerDefaultModelFor": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onContentHandlerDefaultModelFor",
+		"EditFilter": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onEditFilter",
+		"EditFormPreloadText": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onEditFormPreloadText",
 		"ShowSearchHitTitle": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onShowSearchHitTitle",
 		"SpecialSearchResultsAppend": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onSpecialSearchResultsAppend"
 	},
 
 	"config": {
+		"WikibaseFacetedSearchEnableInWikiConfig": {
+			"description": "If it should be possible to define configuration via MediaWiki:WikibaseFacetedSearch",
+			"value": true
+		},
+		"WikibaseFacetedSearch": {
+			"description": "Config in JSON format, following the JSON Schema at schema.json. Gets combined with config defined on MediaWiki:WikibaseFacetedSearch",
+			"value": ""
+		}
+	},
+
+	"SpecialPages": {
+		"WikibaseFacetedSearchConfig": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\SpecialWikibaseFacetedSearchConfig"
 	},
 
 	"ResourceFileModulePaths": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,5 +6,13 @@
 			"Morne Alberts"
 		]
 	},
-	"wikibasefacetedsearch-description": "Enhances [[Special:Search]] with faceted search capabilities. Filter results based on instance type or statement values."
+	"wikibasefacetedsearch-description": "Enhances [[Special:Search]] with faceted search capabilities. Filter results based on instance type or statement values.",
+
+	"special-wikibase-faceted-search-config": "Faceted search configuration",
+
+	"wikibase-faceted-search-config-invalid": "Your changes were not saved. They contain the following {{PLURAL:$1|error|errors}}:",
+
+	"wikibase-faceted-search-config-help-documentation": "You can [[#Documentation|view the configuration documentation]] below the edit area.",
+	"wikibase-faceted-search-config-help": "Configuration documentation",
+	"wikibase-faceted-search-config-help-example": "Full example"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -6,5 +6,10 @@
 			"Morne Alberts"
 		]
 	},
-	"wikibasefacetedsearch-description": "{{Desc|name=WikibaseFacetedSearch|url=https://github.com/ProfessionalWiki/WikibaseFacetedSearch}}"
+	"wikibasefacetedsearch-description": "{{Desc|name=WikibaseFacetedSearch|url=https://github.com/ProfessionalWiki/WikibaseFacetedSearch}}",
+	"special-wikibase-faceted-search-config": "This is the label on \"Special:WikibaseFacetedSearchConfig\" linking to \"MediaWiki:WikibaseFacetedSearch\".",
+	"wikibase-faceted-search-config-invalid": "Error message shown when attempting to save invalid configuration on MediaWiki:WikibaseFacetedSearch",
+	"wikibase-faceted-search-config-help-documentation": "Link to documentation displayed on \"MediaWiki:WikibaseFacetedSearch\"",
+	"wikibase-faceted-search-config-help": "Help text heading displayed on \"MediaWiki:WikibaseFacetedSearch\"",
+	"wikibase-faceted-search-config-help-example": "Help text heading displayed on \"MediaWiki:WikibaseFacetedSearch\""
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,3 +11,21 @@ parameters:
 			identifier: parameterByRef.unusedType
 			count: 1
 			path: src/EntryPoints/WikibaseFacetedSearchHooks.php
+
+		-
+			message: '#^Parameter \#1 \$configArray of method ProfessionalWiki\\WikibaseFacetedSearch\\Persistence\\ConfigDeserializer\:\:newConfig\(\) expects array\<string, mixed\>, array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Persistence/ConfigDeserializer.php
+
+		-
+			message: '#^Parameter \$linkTargetSitelinkSiteId of class ProfessionalWiki\\WikibaseFacetedSearch\\Application\\Config constructor expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Persistence/ConfigDeserializer.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 1
+			path: src/WikibaseFacetedSearchExtension.php

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,12 @@
+{
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"linkTargetSitelinkSiteId": {
+			"type": [
+				"string",
+				"null"
+			]
+		}
+	}
+}

--- a/src/Application/Config.php
+++ b/src/Application/Config.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Application;
+
+class Config {
+
+	public function __construct(
+		public readonly ?string $linkTargetSitelinkSiteId = null
+	) {
+	}
+
+	public function combine( Config $config ): self {
+		return new Config(
+			$config->linkTargetSitelinkSiteId ?? $this->linkTargetSitelinkSiteId
+		);
+	}
+
+}

--- a/src/EntryPoints/SpecialWikibaseFacetedSearchConfig.php
+++ b/src/EntryPoints/SpecialWikibaseFacetedSearchConfig.php
@@ -1,0 +1,36 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\EntryPoints;
+
+use Message;
+use ProfessionalWiki\WikibaseFacetedSearch\WikibaseFacetedSearchExtension;
+use SpecialPage;
+use Title;
+
+class SpecialWikibaseFacetedSearchConfig extends SpecialPage {
+
+	public function __construct() {
+		parent::__construct( 'WikibaseFacetedSearchConfig' );
+	}
+
+	public function execute( $subPage ): void {
+		parent::execute( $subPage );
+
+		$title = Title::newFromText( WikibaseFacetedSearchExtension::CONFIG_PAGE_TITLE, NS_MEDIAWIKI );
+
+		if ( $title instanceof Title ) {
+			$this->getOutput()->redirect( $title->getFullURL() );
+		}
+	}
+
+	public function getGroupName(): string {
+		return 'wikibase';
+	}
+
+	public function getDescription(): Message {
+		return $this->msg( 'special-wikibase-faceted-search-config' );
+	}
+
+}

--- a/src/EntryPoints/WikibaseFacetedSearchHooks.php
+++ b/src/EntryPoints/WikibaseFacetedSearchHooks.php
@@ -4,12 +4,18 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\EntryPoints;
 
+use EditPage;
+use Html;
 use HtmlArmor;
 use IContextSource;
 use Language;
 use OutputPage;
+use ProfessionalWiki\WikibaseFacetedSearch\Persistence\ConfigJsonValidator;
+use ProfessionalWiki\WikibaseFacetedSearch\Presentation\ConfigJsonErrorFormatter;
+use ProfessionalWiki\WikibaseFacetedSearch\Presentation\ExportConfigEditPageTextBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\WikibaseFacetedSearchExtension;
 use SearchResult;
+use Skin;
 use SpecialSearch;
 use Title;
 use Wikibase\DataModel\Entity\ItemId;
@@ -133,8 +139,72 @@ class WikibaseFacetedSearchHooks {
 		// TODO: generate facets from search term
 		$output->addModuleStyles( 'ext.wikibase.facetedsearch.styles' );
 		$output->addHTML(
-			\Html::element( 'div', [ 'class' => 'wikibase-faceted-search__facets' ] )
+			Html::element( 'div', [ 'class' => 'wikibase-faceted-search__facets' ] )
 		);
+	}
+
+	public static function onContentHandlerDefaultModelFor( Title $title, ?string &$model ): void {
+		if ( WikibaseFacetedSearchExtension::getInstance()->isConfigTitle( $title ) ) {
+			$model = CONTENT_MODEL_JSON;
+		}
+	}
+
+	public static function onEditFilter( EditPage $editPage, ?string $text, ?string $section, string &$error ): void {
+		$validator = ConfigJsonValidator::newInstance();
+
+		if ( is_string( $text )
+			&& WikibaseFacetedSearchExtension::getInstance()->isConfigTitle( $editPage->getTitle() )
+			&& !$validator->validate( $text )
+		) {
+			$errors = $validator->getErrors();
+			$error = Html::errorBox(
+				wfMessage( 'wikibase-faceted-search-config-invalid', count( $errors ) )->escaped() .
+				ConfigJsonErrorFormatter::format( $errors )
+			);
+		}
+	}
+
+	public static function onAlternateEdit( EditPage $editPage ): void {
+		if ( WikibaseFacetedSearchExtension::getInstance()->isConfigTitle( $editPage->getTitle() ) ) {
+			$editPage->suppressIntro = true;
+
+			$textBuilder = new ExportConfigEditPageTextBuilder( $editPage->getContext() );
+			$editPage->editFormTextTop = $textBuilder->createTopHtml();
+			$editPage->editFormTextBottom = $textBuilder->createBottomHtml();
+		}
+	}
+
+	public static function onEditFormPreloadText( string &$text, Title &$title ): void {
+		if ( WikibaseFacetedSearchExtension::getInstance()->isConfigTitle( $title ) ) {
+			$text = trim( '
+{
+	"linkTargetSitelinkSiteId": null
+}' );
+		}
+	}
+
+	public static function onBeforePageDisplay( OutputPage $out, Skin $skin ): void {
+		$title = $out->getTitle();
+
+		if ( $title === null ) {
+			return;
+		}
+
+		if ( WikibaseFacetedSearchExtension::getInstance()->isConfigTitle( $title ) ) {
+			$html = $out->getHTML();
+			$out->clearHTML();
+			$out->addHTML( self::getConfigPageHtml( $html ) );
+		}
+	}
+
+	private static function getConfigPageHtml( string $html ): string {
+		$jsonTablePosition = strpos( $html, '<table class="mw-json">' );
+
+		if ( !$jsonTablePosition ) {
+			return $html;
+		}
+
+		return substr( $html, $jsonTablePosition );
 	}
 
 }

--- a/src/Persistence/CombiningConfigLookup.php
+++ b/src/Persistence/CombiningConfigLookup.php
@@ -1,0 +1,40 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence;
+
+use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
+
+/**
+ * Combines these config sources, with the latter overriding the former:
+ * * Defaults
+ * * $baseConfig (LocalSettings.php)
+ * * ConfigLookup (MediaWiki:WikibaseFacetedSearch)
+ */
+class CombiningConfigLookup implements ConfigLookup {
+
+	public function __construct(
+		private readonly string $baseConfig,
+		private readonly ConfigDeserializer $deserializer,
+		private readonly ConfigLookup $configLookup,
+		private readonly bool $enableWikiConfig
+	) {
+	}
+
+	public function getConfig(): Config {
+		$config = $this->createDefaultConfig()->combine(
+			$this->deserializer->deserialize( $this->baseConfig )
+		);
+
+		if ( !$this->enableWikiConfig ) {
+			return $config;
+		}
+
+		return $config->combine( $this->configLookup->getConfig() );
+	}
+
+	private function createDefaultConfig(): Config {
+		return new Config();
+	}
+}

--- a/src/Persistence/ConfigDeserializer.php
+++ b/src/Persistence/ConfigDeserializer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence;
+
+use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
+
+class ConfigDeserializer {
+
+	public function __construct(
+		private readonly ConfigJsonValidator $validator
+	) {
+	}
+
+	public function deserialize( string $configJson ): Config {
+		if ( $this->validator->validate( $configJson ) ) {
+			$configArray = json_decode( $configJson, true );
+
+			if ( is_array( $configArray ) ) {
+				return $this->newConfig( $configArray );
+			}
+		}
+
+		return new Config();
+	}
+
+	/**
+	 * @param array<string, mixed> $configArray
+	 */
+	private function newConfig( array $configArray ): Config {
+		return new Config(
+			linkTargetSitelinkSiteId: $configArray['linkTargetSitelinkSiteId'] ?? null,
+		);
+	}
+
+}

--- a/src/Persistence/ConfigJsonValidator.php
+++ b/src/Persistence/ConfigJsonValidator.php
@@ -1,0 +1,69 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence;
+
+use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Errors\ValidationError;
+use Opis\JsonSchema\Validator;
+use RuntimeException;
+
+class ConfigJsonValidator {
+
+	/**
+	 * @var string[]
+	 */
+	private array $errors = [];
+
+	public static function newInstance(): self {
+		$json = file_get_contents( __DIR__ . '/../../schema.json' );
+
+		if ( !is_string( $json ) ) {
+			throw new RuntimeException( 'Could not obtain JSON Schema' );
+		}
+
+		$schema = json_decode( $json );
+
+		if ( !is_object( $schema ) ) {
+			throw new RuntimeException( 'Failed to deserialize JSON Schema' );
+		}
+
+		return new self( $schema );
+	}
+
+	private function __construct(
+		private readonly object $jsonSchema
+	) {
+	}
+
+	public function validate( string $config ): bool {
+		$validator = new Validator();
+		$validator->setMaxErrors( 10 );
+
+		$validationResult = $validator->validate( json_decode( $config ), $this->jsonSchema );
+
+		$error = $validationResult->error();
+
+		if ( $error !== null ) {
+			$this->errors = $this->formatErrors( $error );
+		}
+
+		return $error === null;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getErrors(): array {
+		return $this->errors;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function formatErrors( ValidationError $error ): array {
+		return ( new ErrorFormatter() )->format( $error, false );
+	}
+
+}

--- a/src/Persistence/ConfigLookup.php
+++ b/src/Persistence/ConfigLookup.php
@@ -1,0 +1,13 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence;
+
+use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
+
+interface ConfigLookup {
+
+	public function getConfig(): Config;
+
+}

--- a/src/Persistence/PageContentConfigLookup.php
+++ b/src/Persistence/PageContentConfigLookup.php
@@ -1,0 +1,33 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence;
+
+use JsonContent;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
+
+class PageContentConfigLookup implements ConfigLookup {
+
+	public function __construct(
+		private readonly PageContentFetcher $contentFetcher,
+		private readonly ConfigDeserializer $deserializer,
+		private readonly string $pageName
+	) {
+	}
+
+	public function getConfig(): Config {
+		$content = $this->contentFetcher->getPageContent( 'MediaWiki:' . $this->pageName );
+
+		if ( $content instanceof \JsonContent ) {
+			return $this->configFromJsonContent( $content );
+		}
+
+		return new Config();
+	}
+
+	private function configFromJsonContent( JsonContent $content ): Config {
+		return $this->deserializer->deserialize( $content->getText() );
+	}
+
+}

--- a/src/Persistence/PageContentFetcher.php
+++ b/src/Persistence/PageContentFetcher.php
@@ -1,0 +1,33 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence;
+
+use Content;
+use MalformedTitleException;
+use MediaWiki\Revision\RevisionLookup;
+use MediaWiki\Revision\SlotRecord;
+use TitleParser;
+
+class PageContentFetcher {
+
+	public function __construct(
+		private readonly TitleParser $titleParser,
+		private readonly RevisionLookup $revisionLookup
+	) {
+	}
+
+	public function getPageContent( string $pageTitle ): ?Content {
+		try {
+			$title = $this->titleParser->parseTitle( $pageTitle );
+		} catch ( MalformedTitleException ) {
+			return null;
+		}
+
+		$revision = $this->revisionLookup->getRevisionByTitle( $title );
+
+		return $revision?->getContent( SlotRecord::MAIN );
+	}
+
+}

--- a/src/Presentation/ConfigJsonErrorFormatter.php
+++ b/src/Presentation/ConfigJsonErrorFormatter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Presentation;
+
+class ConfigJsonErrorFormatter {
+
+	/**
+	 * @param string[] $errors
+	 */
+	public static function format( array $errors ): string {
+		$html = '<table class="wikitable">';
+
+		foreach ( $errors as $key => $value ) {
+			$html .= '<tr><td>' . htmlspecialchars( $key ) . '</td>';
+			$html .= '<td>' . htmlspecialchars( $value ) . '</td></tr>';
+		}
+
+		$html .= '</table>';
+
+		return $html;
+	}
+
+}

--- a/src/Presentation/ExportConfigEditPageTextBuilder.php
+++ b/src/Presentation/ExportConfigEditPageTextBuilder.php
@@ -1,0 +1,81 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Presentation;
+
+use IContextSource;
+
+class ExportConfigEditPageTextBuilder {
+
+	public function __construct(
+		private IContextSource $context
+	) {
+	}
+
+	public function createTopHtml(): string {
+		return '<div id="wikibase-faceted-search-config-help-top">' .
+			$this->createDocumentationLink() .
+			'</div>';
+	}
+
+	private function createDocumentationLink(): string {
+		return '<p>'
+			. $this->context->msg( 'wikibase-faceted-search-config-help-documentation' )->parse()
+			. '</p>';
+	}
+
+	public function createBottomHtml(): string {
+		return <<<HTML
+<div id="Documentation">
+	<section>
+		<h2 id="ConfigurationDocumentation">{$this->context->msg( 'wikibase-faceted-search-config-help' )->escaped()}</h2>
+
+		<p>
+			Besides the configuration reference below, you can consult the Wikibase Faceted Search
+			<a href="https://professional.wiki/en/extension/wikibase-faceted-search">usage documentation</a> and
+			<a href="https://facetedsearch.wikibase.wiki">demo wiki</a>.
+		</p>
+	</section>
+
+	<section>
+		<h2 id="LinkTargetSitelinkSiteId">Link target sitelink site ID</h2>
+
+		<p>
+			By default search result items link to their item page (<code>Item:Q123</code>).
+		</p>
+
+		<p>
+			You can change the link to use a sitelink of the item instead.
+		</p>
+
+		<p>
+			Example configuration:
+		</p>
+
+		<pre>
+{
+	"linkTargetSitelinkSiteId": "enwiki"
+}</pre>
+	</section>
+
+	<section>
+		<h2 id="FullExample">{$this->context->msg( 'wikibase-faceted-search-config-help-example' )->escaped()}</h2>
+
+		<pre>{$this->getExampleContents()}</pre>
+	</section>
+</div>
+HTML;
+	}
+
+	private function getExampleContents(): string {
+		$example = file_get_contents( __DIR__ . '/../../example.json' );
+
+		if ( !is_string( $example ) ) {
+			return '';
+		}
+
+		return $example;
+	}
+
+}

--- a/tests/Application/ConfigTest.php
+++ b/tests/Application/ConfigTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseFacetedSearch\Application\Config
+ */
+class ConfigTest extends TestCase {
+
+	private function createOriginalConfig(): Config {
+		return new Config(
+			linkTargetSitelinkSiteId: 'enwiki'
+		);
+	}
+
+	private function createNewConfig(): Config {
+		return new Config(
+			linkTargetSitelinkSiteId: 'dewiki'
+		);
+	}
+
+	public function testOriginalValuesAreKeptWhenCombined(): void {
+		$original = $this->createOriginalConfig();
+		$new = new Config();
+
+		$combined = $original->combine( $new );
+
+		$this->assertEquals( $original, $combined );
+	}
+
+	public function testOriginalValuesAreReplacedWhenCombined(): void {
+		$original = $this->createOriginalConfig();
+		$new = $this->createNewConfig();
+
+		$combined = $original->combine( $new );
+
+		$this->assertEquals( $new, $combined );
+	}
+
+}

--- a/tests/Persistence/CombiningConfigLookupTest.php
+++ b/tests/Persistence/CombiningConfigLookupTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Persistence;
+
+use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
+use ProfessionalWiki\WikibaseFacetedSearch\Persistence\CombiningConfigLookup;
+use ProfessionalWiki\WikibaseFacetedSearch\Tests\TestDoubles\StubConfigLookup;
+use ProfessionalWiki\WikibaseFacetedSearch\Tests\WikibaseFacetedSearchIntegrationTest;
+use ProfessionalWiki\WikibaseFacetedSearch\WikibaseFacetedSearchExtension;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseFacetedSearch\Persistence\CombiningConfigLookup
+ */
+class CombiningConfigLookupTest extends WikibaseFacetedSearchIntegrationTest {
+
+	private function newLookup( string $baseConfig, Config $wikiConfig, bool $enableWikiConfig ): CombiningConfigLookup {
+		return new CombiningConfigLookup(
+			baseConfig: $baseConfig,
+			deserializer: WikibaseFacetedSearchExtension::getInstance()->newConfigDeserializer(),
+			configLookup: new StubConfigLookup( $wikiConfig ),
+			enableWikiConfig: $enableWikiConfig
+		);
+	}
+
+	public function testWikiConfigSupersedesBaseConfig(): void {
+		$lookup = $this->newLookup(
+			baseConfig: '{ "linkTargetSitelinkSiteId": "enwiki" }',
+			wikiConfig: new Config( linkTargetSitelinkSiteId: 'dewiki' ),
+			enableWikiConfig: true
+		);
+
+		$this->assertSame(
+			'dewiki',
+			$lookup->getConfig()->linkTargetSitelinkSiteId
+		);
+	}
+
+	public function testUsesBaseConfigIfThereIsNoWikiConfig(): void {
+		$lookup = $this->newLookup(
+			baseConfig: '{ "linkTargetSitelinkSiteId": "enwiki" }',
+			wikiConfig: new Config(),
+			enableWikiConfig: true
+		);
+
+		$this->assertSame(
+			'enwiki',
+			$lookup->getConfig()->linkTargetSitelinkSiteId
+		);
+	}
+
+	public function testOnlyUsesWikiConfigWhenEnabled(): void {
+		$lookup = $this->newLookup(
+			baseConfig: '{ "linkTargetSitelinkSiteId": "enwiki" }',
+			wikiConfig: new Config( linkTargetSitelinkSiteId: 'dewiki' ),
+			enableWikiConfig: false
+		);
+
+		$this->assertSame(
+			'enwiki',
+			$lookup->getConfig()->linkTargetSitelinkSiteId
+		);
+	}
+
+}

--- a/tests/Persistence/ConfigDeserializerTest.php
+++ b/tests/Persistence/ConfigDeserializerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Persistence;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
+use ProfessionalWiki\WikibaseFacetedSearch\Tests\TestDoubles\Valid;
+use ProfessionalWiki\WikibaseFacetedSearch\WikibaseFacetedSearchExtension;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseFacetedSearch\Persistence\ConfigDeserializer
+ */
+class ConfigDeserializerTest extends TestCase {
+
+	public function testValidJsonReturnsConfig(): void {
+		$deserializer = WikibaseFacetedSearchExtension::getInstance()->newConfigDeserializer();
+
+		$config = $deserializer->deserialize( Valid::configJson() );
+
+		$this->assertEquals(
+			new Config(
+				linkTargetSitelinkSiteId: 'enwiki'
+			),
+			$config
+		);
+	}
+
+	public function testInvalidJsonReturnsEmptyConfig(): void {
+		$deserializer = WikibaseFacetedSearchExtension::getInstance()->newConfigDeserializer();
+
+		$config = $deserializer->deserialize( '}{' );
+		$emptyConfig = new Config();
+
+		$this->assertEquals( $emptyConfig, $config );
+	}
+
+}

--- a/tests/Persistence/ConfigJsonValidatorTest.php
+++ b/tests/Persistence/ConfigJsonValidatorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Persistence;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseFacetedSearch\Persistence\ConfigJsonValidator;
+use ProfessionalWiki\WikibaseFacetedSearch\Tests\TestDoubles\Valid;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseFacetedSearch\Persistence\ConfigJsonValidator
+ */
+class ConfigJsonValidatorTest extends TestCase {
+
+	public function testEmptyJsonPassesValidation(): void {
+		$this->assertTrue(
+			ConfigJsonValidator::newInstance()->validate( '{}' )
+		);
+	}
+
+	public function testValidJsonPassesValidation(): void {
+		$this->assertTrue(
+			ConfigJsonValidator::newInstance()->validate( Valid::configJson() )
+		);
+	}
+
+	public function testStructurallyInvalidJsonFailsValidation(): void {
+		$this->assertFalse(
+			ConfigJsonValidator::newInstance()->validate( '}{' )
+		);
+	}
+
+	public function testInvalidJsonErrorsAreAvailable(): void {
+		$validator = ConfigJsonValidator::newInstance();
+
+		$validator->validate( '{ "linkTargetSitelinkSiteId": true }' );
+
+		$this->assertSame(
+			[ '/linkTargetSitelinkSiteId' => 'The data (boolean) must match the type: string, null' ],
+			$validator->getErrors()
+		);
+	}
+
+}

--- a/tests/Persistence/PageContentConfigLookupTest.php
+++ b/tests/Persistence/PageContentConfigLookupTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Persistence;
+
+use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
+use ProfessionalWiki\WikibaseFacetedSearch\Tests\TestDoubles\Valid;
+use ProfessionalWiki\WikibaseFacetedSearch\Tests\WikibaseFacetedSearchIntegrationTest;
+use ProfessionalWiki\WikibaseFacetedSearch\WikibaseFacetedSearchExtension;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseFacetedSearch\Persistence\PageContentConfigLookup
+ * @group Database
+ */
+class PageContentConfigLookupTest extends WikibaseFacetedSearchIntegrationTest {
+
+	public function testEmptyPageConfig(): void {
+		$this->editConfigPage( '{}' );
+		$lookup = WikibaseFacetedSearchExtension::getInstance()->newPageContentConfigLookup();
+
+		$config = $lookup->getConfig();
+		$emptyConfig = new Config();
+
+		$this->assertEquals( $emptyConfig, $config );
+	}
+
+	public function testSavedPageConfig(): void {
+		$this->editConfigPage( Valid::configJson() );
+		$lookup = WikibaseFacetedSearchExtension::getInstance()->newPageContentConfigLookup();
+
+		$config = $lookup->getConfig();
+
+		$this->assertEquals(
+			new Config(
+				linkTargetSitelinkSiteId: 'enwiki'
+			),
+			$config
+		);
+	}
+
+}

--- a/tests/TestDoubles/StubConfigLookup.php
+++ b/tests/TestDoubles/StubConfigLookup.php
@@ -1,0 +1,21 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\TestDoubles;
+
+use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
+use ProfessionalWiki\WikibaseFacetedSearch\Persistence\ConfigLookup;
+
+class StubConfigLookup implements ConfigLookup {
+
+	public function __construct(
+		private Config $config
+	) {
+	}
+
+	public function getConfig(): Config {
+		return $this->config;
+	}
+
+}

--- a/tests/TestDoubles/Valid.php
+++ b/tests/TestDoubles/Valid.php
@@ -1,0 +1,17 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\TestDoubles;
+
+class Valid {
+
+	public static function configJson(): string {
+		return '
+{
+    "linkTargetSitelinkSiteId": "enwiki"
+}
+';
+	}
+
+}

--- a/tests/WikibaseFacetedSearchIntegrationTest.php
+++ b/tests/WikibaseFacetedSearchIntegrationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Tests;
+
+use Article;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\WikibaseFacetedSearch\WikibaseFacetedSearchExtension;
+
+class WikibaseFacetedSearchIntegrationTest extends MediaWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		WikibaseFacetedSearchExtension::getInstance()->clearConfig();
+	}
+
+	protected function editConfigPage( string $config ): void {
+		$this->editPage(
+			'MediaWiki:' . WikibaseFacetedSearchExtension::CONFIG_PAGE_TITLE,
+			$config
+		);
+	}
+
+	protected function getPageHtml( string $pageTitle ): string {
+		$title = \Title::newFromText( $pageTitle );
+
+		$article = new Article( $title, 0 );
+		$article->getContext()->getOutput()->setTitle( $title );
+
+		$article->view();
+
+		return $article->getContext()->getOutput()->getHTML();
+	}
+
+	protected function getEditPageHtml( string $pageTitle ): string {
+		$title = \Title::newFromText( $pageTitle );
+
+		$article = new Article( $title, 0 );
+		$article->getContext()->getOutput()->setTitle( $title );
+
+		$editPage = new \EditPage( $article );
+		$editPage->setContextTitle( $title );
+		$editPage->getContext()->setUser( $this->getTestSysop()->getUser() );
+		$editPage->edit();
+
+		return $editPage->getContext()->getOutput()->getHTML();
+	}
+
+}


### PR DESCRIPTION
For #12 

Based on https://github.com/ProfessionalWiki/WikibaseExport config.
Supports JSON config in LocalSettings and on `MediaWiki:WikibaseFacetedSearch`.
Adds config for sitelink: https://github.com/ProfessionalWiki/WikibaseFacetedSearch/pull/24

Documentation improvements can be done in follow-up.

----

On `Special:SpecialPages`:
![image](https://github.com/user-attachments/assets/4eb3bf60-08fb-48a9-81a7-457e5fdd186b)

Empty `MediaWiki:WikibaseFacetedSearch`:
![Screenshot_20241130_183547](https://github.com/user-attachments/assets/16640595-6ebb-486e-ac02-649fceaecbd6)

First edit:
![image](https://github.com/user-attachments/assets/5be48363-78eb-43a3-996e-e51d175150ae)

After edit:
![Screenshot_20241130_183659](https://github.com/user-attachments/assets/9f47b2cc-45cd-4127-9ee5-eabf324b067d)'

Validation:
![Screenshot_20241130_183737](https://github.com/user-attachments/assets/6248d9da-cf3f-48a9-a7d0-931d58091cf5)

