### PR TITLE
Add new keyword placeholder

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -42,7 +42,8 @@
 		"EditFilter": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onEditFilter",
 		"EditFormPreloadText": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onEditFormPreloadText",
 		"ShowSearchHitTitle": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onShowSearchHitTitle",
-		"SpecialSearchResultsAppend": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onSpecialSearchResultsAppend"
+		"SpecialSearchResultsAppend": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onSpecialSearchResultsAppend",
+		"CirrusSearchAddQueryFeatures":  "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onCirrusSearchAddQueryFeatures"
 	},
 
 	"config": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,6 +37,12 @@ parameters:
 			path: src/Persistence/ConfigDeserializer.php
 
 		-
+			message: '#^Method ProfessionalWiki\\WikibaseFacetedSearch\\Persistence\\Search\\Query\\HasWbFacetFeature\:\:doApply\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Persistence/Search/Query/HasWbFacetFeature.php
+
+		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
 			count: 1

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,3 +14,6 @@ parameters:
 		- ../../extensions/WikibaseCirrusSearch
 	bootstrapFiles:
 		- ../../includes/AutoLoader.php
+	excludePaths:
+		- src/EntryPoints/WikibaseFacetedSearchHooks.php
+		- src/Persistence/Search/Query/HasWbFacetFeature.php

--- a/src/EntryPoints/WikibaseFacetedSearchHooks.php
+++ b/src/EntryPoints/WikibaseFacetedSearchHooks.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\EntryPoints;
 
+use CirrusSearch\Query\KeywordFeature;
+use CirrusSearch\SearchConfig;
 use EditPage;
 use Html;
 use HtmlArmor;
@@ -11,6 +13,7 @@ use IContextSource;
 use Language;
 use OutputPage;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\ConfigJsonValidator;
+use ProfessionalWiki\WikibaseFacetedSearch\Persistence\Search\Query\HasWbFacetFeature;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\ConfigJsonErrorFormatter;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\ExportConfigEditPageTextBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\WikibaseFacetedSearchExtension;
@@ -209,6 +212,13 @@ class WikibaseFacetedSearchHooks {
 		}
 
 		return substr( $html, $jsonTablePosition );
+	}
+
+	/**
+	 * @param KeywordFeature[] &$extraFeatures
+	 */
+	public static function onCirrusSearchAddQueryFeatures( SearchConfig $config, array &$extraFeatures ): void {
+		$extraFeatures[] = new HasWbFacetFeature();
 	}
 
 }

--- a/src/Persistence/Search/Query/HasWbFacetFeature.php
+++ b/src/Persistence/Search/Query/HasWbFacetFeature.php
@@ -1,0 +1,36 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence\Search\Query;
+
+use CirrusSearch\Parser\AST\KeywordFeatureNode;
+use CirrusSearch\Query\Builder\QueryBuildingContext;
+use CirrusSearch\Query\FilterQueryFeature;
+use CirrusSearch\Query\SimpleKeywordFeature;
+use CirrusSearch\Search\SearchContext;
+use Elastica\Query\AbstractQuery;
+
+class HasWbFacetFeature extends SimpleKeywordFeature implements FilterQueryFeature {
+
+	/**
+	 * @return string[]
+	 */
+	protected function getKeywords(): array {
+		return [ 'haswbfacet' ];
+	}
+
+	/**
+	 * @return array
+	 */
+	protected function doApply( SearchContext $context, $key, $value, $quotedValue, $negated ): array {
+		// TODO
+		return [ null, false ];
+	}
+
+	public function getFilterQuery( KeywordFeatureNode $node, QueryBuildingContext $context ): ?AbstractQuery {
+		// TODO
+		return null;
+	}
+
+}

--- a/tests/Persistence/Search/Query/HasWbFacetFeatureTest.php
+++ b/tests/Persistence/Search/Query/HasWbFacetFeatureTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Persistence\Search\Query;
+
+use CirrusSearch\Query\KeywordFeatureAssertions;
+use ProfessionalWiki\WikibaseFacetedSearch\Persistence\Search\Query\HasWbFacetFeature;
+use ProfessionalWiki\WikibaseFacetedSearch\Tests\WikibaseFacetedSearchIntegrationTest;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseFacetedSearch\Persistence\Search\Query\HasWbFacetFeature
+ */
+class HasWbFacetFeatureTest extends WikibaseFacetedSearchIntegrationTest {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->markTestSkippedIfExtensionNotLoaded( 'CirrusSearch' );
+	}
+
+	/**
+	 * @dataProvider noDataProvider
+	 */
+	public function testNotConsumed( $term ) {
+		$feature = new HasWbFacetFeature();
+		$this->getKWAssertions()->assertNotConsumed( $feature, $term );
+	}
+
+	public static function noDataProvider() {
+		return [
+			'empty data' => [
+				'haswbfacet:',
+			],
+			'no data' => [
+				'',
+			],
+		];
+	}
+
+	/**
+	 * @return KeywordFeatureAssertions
+	 */
+	private function getKWAssertions() {
+		return new KeywordFeatureAssertions( $this );
+	}
+
+}


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/WikibaseFacetedSearch/issues/38

Doesn't do anything yet.

I went with `haswbfacet` because:
* `haswb...` is the pattern used in WikibaseCirrusSearch
* `facet`, in general, refers to a specific aspect an object. This is reflected in how our new keyword is going to support a subset of `haswbstatement`, specifically limiting keyword usage to one facet (property) at a time.

I suppose we can bikeshed this later.