### PR TITLE
Add initial search fields

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -43,7 +43,8 @@
 		"EditFormPreloadText": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onEditFormPreloadText",
 		"ShowSearchHitTitle": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onShowSearchHitTitle",
 		"SpecialSearchResultsAppend": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onSpecialSearchResultsAppend",
-		"CirrusSearchAddQueryFeatures":  "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onCirrusSearchAddQueryFeatures"
+		"CirrusSearchAddQueryFeatures":  "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onCirrusSearchAddQueryFeatures",
+		"SearchIndexFields": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onSearchIndexFields"
 	},
 
 	"config": {

--- a/src/EntryPoints/WikibaseFacetedSearchHooks.php
+++ b/src/EntryPoints/WikibaseFacetedSearchHooks.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\EntryPoints;
 
+use CirrusSearch\CirrusSearch;
 use CirrusSearch\Query\KeywordFeature;
 use CirrusSearch\SearchConfig;
 use EditPage;
@@ -17,6 +18,8 @@ use ProfessionalWiki\WikibaseFacetedSearch\Persistence\Search\Query\HasWbFacetFe
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\ConfigJsonErrorFormatter;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\ExportConfigEditPageTextBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\WikibaseFacetedSearchExtension;
+use SearchEngine;
+use SearchIndexField;
 use SearchResult;
 use Skin;
 use SpecialSearch;
@@ -222,6 +225,20 @@ class WikibaseFacetedSearchHooks {
 	 */
 	public static function onCirrusSearchAddQueryFeatures( SearchConfig $config, array &$extraFeatures ): void {
 		$extraFeatures[] = new HasWbFacetFeature();
+	}
+
+	/**
+	 * @param SearchIndexField[] $fields
+	 */
+	public static function onSearchIndexFields( array &$fields, SearchEngine $engine ): void {
+		if ( !( $engine instanceof CirrusSearch ) ) {
+			return;
+		}
+
+		$fields = array_merge(
+			$fields,
+			WikibaseFacetedSearchExtension::getInstance()->newFacetSearchIndexFieldsBuilder( $engine )->createFields()
+		);
 	}
 
 }

--- a/src/Persistence/Search/FacetSearchIndexFieldsBuilder.php
+++ b/src/Persistence/Search/FacetSearchIndexFieldsBuilder.php
@@ -1,0 +1,59 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence\Search;
+
+use Exception;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
+use SearchEngine;
+use SearchIndexField;
+use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookup;
+
+class FacetSearchIndexFieldsBuilder {
+
+	public function __construct(
+		private readonly SearchEngine $engine,
+		private readonly Config $config,
+		private readonly PropertyDataTypeLookup $dataTypeLookup
+	) {
+	}
+
+	/**
+	 * @return array<string, SearchIndexField>
+	 */
+	public function createFields(): array {
+		$fields = [];
+
+		foreach ( $this->config->getFacets()->asArray() as $facetConfig ) {
+			$name = 'wbfs_' . $facetConfig->propertyId->getSerialization();
+
+			try {
+				$dataTypeId = $this->dataTypeLookup->getDataTypeIdForProperty( $facetConfig->propertyId );
+			} catch ( Exception $e ) {
+				continue;
+			}
+
+			$fieldType = $this->getFieldTypeForDataTypeId( $dataTypeId );
+
+			if ( $fieldType === null ) {
+				continue;
+			}
+
+			$fields[$name] = $this->engine->makeSearchFieldMapping( $name, $fieldType );
+		}
+
+		return $fields;
+	}
+
+	private function getFieldTypeForDataTypeId( string $dataTypeId ): ?string {
+		return match ( $dataTypeId ) {
+			'quantity' => SearchIndexField::INDEX_TYPE_NUMBER,
+			'string' => SearchIndexField::INDEX_TYPE_KEYWORD,
+			'time' => SearchIndexField::INDEX_TYPE_DATETIME,
+			'wikibase-item' => SearchIndexField::INDEX_TYPE_KEYWORD,
+			default => null
+		};
+	}
+
+}

--- a/src/WikibaseFacetedSearchExtension.php
+++ b/src/WikibaseFacetedSearchExtension.php
@@ -6,17 +6,20 @@ namespace ProfessionalWiki\WikibaseFacetedSearch;
 
 use MediaWiki\MediaWikiServices;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\ConfigLookup;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\ItemPageLookup;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\CombiningConfigLookup;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\ConfigDeserializer;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\ConfigJsonValidator;
-use ProfessionalWiki\WikibaseFacetedSearch\Application\ConfigLookup;
-use ProfessionalWiki\WikibaseFacetedSearch\Application\ItemPageLookup;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\ItemPageLookupFactory;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\PageContentConfigLookup;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\PageContentFetcher;
+use ProfessionalWiki\WikibaseFacetedSearch\Persistence\Search\FacetSearchIndexFieldsBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\FacetUiBuilder;
+use SearchEngine;
 use TemplateParser;
 use Title;
+use Wikibase\Repo\WikibaseRepo;
 
 class WikibaseFacetedSearchExtension {
 
@@ -84,6 +87,14 @@ class WikibaseFacetedSearchExtension {
 		return new FacetUiBuilder(
 			parser: new TemplateParser( __DIR__ . '/../templates' ),
 			config: $this->getConfig()
+		);
+	}
+
+	public function newFacetSearchIndexFieldsBuilder( SearchEngine $engine ): FacetSearchIndexFieldsBuilder {
+		return new FacetSearchIndexFieldsBuilder(
+			engine:	$engine,
+			config: $this->getConfig(),
+			dataTypeLookup: WikibaseRepo::getPropertyDataTypeLookup()
 		);
 	}
 

--- a/tests/Persistence/Search/FacetSearchIndexFieldsBuilderTest.php
+++ b/tests/Persistence/Search/FacetSearchIndexFieldsBuilderTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence\Search;
+
+use CirrusSearch\CirrusSearch;
+use CirrusSearch\Search\DatetimeIndexField;
+use CirrusSearch\Search\KeywordIndexField;
+use CirrusSearch\Search\NumberIndexField;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\FacetConfig;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\FacetConfigList;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\FacetType;
+use SearchIndexField;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\NumericPropertyId;
+use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Services\Lookup\InMemoryDataTypeLookup;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseFacetedSearch\Persistence\Search\FacetSearchIndexFieldsBuilder
+ */
+class FacetSearchIndexFieldsBuilderTest extends TestCase {
+
+	private CirrusSearch $cirrusSearch;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->cirrusSearch = new CirrusSearch();
+	}
+
+	public function testEmptyConfigReturnsNoFields(): void {
+		$builder = $this->newBuilder( new Config() );
+
+		$this->assertSame( [], $builder->createFields() );
+	}
+
+	private function newBuilder( Config $config ): FacetSearchIndexFieldsBuilder {
+		return new FacetSearchIndexFieldsBuilder(
+			$this->cirrusSearch,
+			$config,
+			$this->newDataTypeLookup()
+		);
+	}
+
+	private function newDataTypeLookup(): InMemoryDataTypeLookup {
+		$dataTypeLookup = new InMemoryDataTypeLookup();
+
+		$types = [
+			'P100' => 'quantity',
+			'P200' => 'string',
+			'P300' => 'time',
+			'P400' => 'wikibase-item'
+		];
+
+		foreach ( $types as $pId => $type ) {
+			$dataTypeLookup->setDataTypeForProperty(
+				new NumericPropertyId( $pId ),
+				$type
+			);
+		}
+
+		return $dataTypeLookup;
+	}
+
+	public function testReturnsFieldsForConfig(): void {
+		$builder = $this->newBuilder(
+			new Config(
+				facets: new FacetConfigList(
+					$this->newFacetConfig( 'Q1', 'P100' ),
+					$this->newFacetConfig( 'Q1', 'P200' ),
+					$this->newFacetConfig( 'Q2', 'P100' ),
+					$this->newFacetConfig( 'Q2', 'P300' ),
+					$this->newFacetConfig( 'Q3', 'P400' )
+				)
+			)
+		);
+
+		$this->assertEquals(
+			[
+				'wbfs_P100' => new NumberIndexField( 'wbfs_P100', SearchIndexField::INDEX_TYPE_NUMBER, $this->cirrusSearch->getConfig() ),
+				'wbfs_P200' => new KeywordIndexField( 'wbfs_P200', SearchIndexField::INDEX_TYPE_KEYWORD, $this->cirrusSearch->getConfig() ),
+				'wbfs_P300' => new DatetimeIndexField( 'wbfs_P300', SearchIndexField::INDEX_TYPE_DATETIME, $this->cirrusSearch->getConfig() ),
+				'wbfs_P400' => new KeywordIndexField( 'wbfs_P400', SearchIndexField::INDEX_TYPE_KEYWORD, $this->cirrusSearch->getConfig() )
+			],
+			$builder->createFields()
+		);
+	}
+
+	private function newFacetConfig( string $instanceTypeId, string $propertyId, ?string $facetType = null ): FacetConfig {
+		return new FacetConfig(
+			new ItemId( $instanceTypeId ),
+			new NumericPropertyId( $propertyId ),
+			$facetType ?? FacetType::LIST
+		);
+	}
+
+	private function newProperty( string $id, string $dataType ): Property {
+		return new Property( new NumericPropertyId( $id ), null, $dataType );
+	}
+
+	public function testDoesNotReturnFieldsForMissingProperties(): void {
+		$builder = $this->newBuilder(
+			new Config(
+				facets: new FacetConfigList(
+					$this->newFacetConfig( 'Q1', 'P100' ),
+					$this->newFacetConfig( 'Q2', 'P404' ),
+					$this->newFacetConfig( 'Q3', 'P200' )
+				)
+			)
+		);
+
+		$this->assertEquals(
+			[
+				'wbfs_P100' => new NumberIndexField( 'wbfs_P100', SearchIndexField::INDEX_TYPE_NUMBER, $this->cirrusSearch->getConfig() ),
+				'wbfs_P200' => new KeywordIndexField( 'wbfs_P200', SearchIndexField::INDEX_TYPE_KEYWORD, $this->cirrusSearch->getConfig() )
+			],
+			$builder->createFields()
+		);
+	}
+
+}


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/WikibaseFacetedSearch/issues/49

Creates an Elasticsearch field for each configured facet.

Example in Kibana:
![Screenshot_20241229_231759](https://github.com/user-attachments/assets/b7310fdf-3abf-433f-81b8-7825da45d6d6)
