### PR TITLE
Add quotes test case

### DIFF
--- a/tests/Application/QueryStringParserTest.php
+++ b/tests/Application/QueryStringParserTest.php
@@ -114,7 +114,7 @@ final class QueryStringParserTest extends TestCase {
 		$this->assertSame( 9001.0, $p23Constraints->getInclusiveMinimum() );
 	}
 
-	public function testHandlesQuotedStrings(): void {
+	public function testHandlesSingleQuotedString(): void {
 		$this->markTestSkipped( 'TODO' );
 
 		$parser = new QueryStringParser();
@@ -125,6 +125,21 @@ final class QueryStringParserTest extends TestCase {
 		$this->assertEquals(
 			[ 'foo bar' ],
 			$constraints->getAndSelectedValues()
+		);
+		$this->assertSame( 'baz', $query->getFreeText() );
+	}
+
+	public function testHandlesOrQuotedStrings(): void {
+		$this->markTestSkipped( 'TODO' );
+
+		$parser = new QueryStringParser();
+		$query = $parser->parse( 'haswbfacet:P42="foo bar"|second|"third value" baz' );
+
+		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
+
+		$this->assertEquals(
+			[ 'foo bar', 'second', 'third value' ],
+			$constraints->getOrSelectedValues()
 		);
 		$this->assertSame( 'baz', $query->getFreeText() );
 	}


### PR DESCRIPTION
Follow-up to #67 

I know it's not implemented yet.

Presumably we'll go with the syntax in the new test case. However, this is different from the `haswbstatement` syntax which includes the property in the quotes:
`haswbstatement:"P225=Prionace glauca"`
https://www.mediawiki.org/wiki/Help:Extension:WikibaseCirrusSearch#haswbstatement