### PR TITLE
Remove final

### DIFF
--- a/src/Application/Query.php
+++ b/src/Application/Query.php
@@ -6,7 +6,7 @@ namespace ProfessionalWiki\WikibaseFacetedSearch\Application;
 
 use Wikibase\DataModel\Entity\PropertyId;
 
-final class Query {
+class Query {
 
 	public function __construct(
 		public readonly PropertyConstraintsList $constraints,

--- a/src/Application/QueryStringParser.php
+++ b/src/Application/QueryStringParser.php
@@ -6,7 +6,7 @@ namespace ProfessionalWiki\WikibaseFacetedSearch\Application;
 
 use Wikibase\DataModel\Entity\NumericPropertyId;
 
-final class QueryStringParser {
+class QueryStringParser {
 
 	public function parse( string $queryString ): Query {
 		$constraints = new PropertyConstraintsList();

--- a/tests/Application/PropertyConstraintsTest.php
+++ b/tests/Application/PropertyConstraintsTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Entity\NumericPropertyId;
 /**
  * @covers \ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraints
  */
-final class PropertyConstraintsTest extends TestCase {
+class PropertyConstraintsTest extends TestCase {
 
 	private const PROPERTY_ID = 'P1';
 

--- a/tests/Application/QueryStringParserTest.php
+++ b/tests/Application/QueryStringParserTest.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Entity\NumericPropertyId;
 /**
  * @covers \ProfessionalWiki\WikibaseFacetedSearch\Application\QueryStringParser
  */
-final class QueryStringParserTest extends TestCase {
+class QueryStringParserTest extends TestCase {
 
 	/**
 	 * @dataProvider freeTextProvider

--- a/tests/Application/QueryTest.php
+++ b/tests/Application/QueryTest.php
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Entity\NumericPropertyId;
  * @covers \ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraintsList
  * @covers \ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraints
  */
-final class QueryTest extends TestCase {
+class QueryTest extends TestCase {
 
 	public function testPropertyConstraintsCanBeRetrieved(): void {
 		$p1Constraint = new PropertyConstraints( new NumericPropertyId( 'P1' ) );


### PR DESCRIPTION
Follow-up to https://github.com/ProfessionalWiki/WikibaseFacetedSearch/pull/67

Rather remove it, otherwise future archeologists won't know what made these explicitly final classes special compared to the other implicitly final classes.