### PR TITLE
Maket Facets UI collapsible below tablet viewport

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -74,9 +74,15 @@
 			"styles": [
 				"ext.wikibase.facetedsearch.less"
 			],
+			"skinStyles": {
+				"chameleon": [ 
+					"ext.wikibase.facetedsearch.chameleon.less"
+				]
+			},
 			"codexStyleOnly": true,
 			"codexComponents": [
 				"CdxAccordion",
+				"CdxButton",
 				"CdxCheckbox",
 				"CdxField",
 				"CdxRadio",

--- a/extension.json
+++ b/extension.json
@@ -75,7 +75,7 @@
 				"ext.wikibase.facetedsearch.less"
 			],
 			"skinStyles": {
-				"chameleon": [ 
+				"chameleon": [
 					"ext.wikibase.facetedsearch.chameleon.less"
 				]
 			},

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -16,6 +16,8 @@
 	"wikibase-faceted-search-config-help": "Configuration documentation",
 	"wikibase-faceted-search-config-help-example": "Full example",
 
+	"wikibase-faceted-search-filters": "Filters",
+
 	"wikibase-faceted-search-facet-range-min": "Minimum",
 	"wikibase-faceted-search-facet-range-max": "Maximum"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -12,6 +12,7 @@
 	"wikibase-faceted-search-config-help-documentation": "Link to documentation displayed on \"MediaWiki:WikibaseFacetedSearch\"",
 	"wikibase-faceted-search-config-help": "Help text heading displayed on \"MediaWiki:WikibaseFacetedSearch\"",
 	"wikibase-faceted-search-config-help-example": "Help text heading displayed on \"MediaWiki:WikibaseFacetedSearch\"",
+	"wikibase-faceted-search-filters": "Label used for the Filters button to toggle the facets",
 	"wikibase-faceted-search-facet-range-min": "Minimum value label displayed on range facet",
 	"wikibase-faceted-search-facet-range-max": "Maximum value label displayed on range facet"
 }

--- a/resources/ext.wikibase.facetedsearch.chameleon.less
+++ b/resources/ext.wikibase.facetedsearch.chameleon.less
@@ -1,0 +1,7 @@
+.wikibase-faceted-search {
+	// Chameleon add a margin-bottom: 0.5em to all <label> elements
+	// We need to reset that to let Codex handles the spacing
+	label {
+		margin-bottom: 0;
+	}
+}

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -53,8 +53,13 @@
 // HACK: Creating a multi-column layout
 // TODO: Find a way to put .wikibase-faceted-search inside .searchresults
 .mw-body-content:has( .wikibase-faceted-search ) {
+	display: grid;
+	grid-template-areas:
+		'searchform'
+		'sidebar'
+		'results';
+
 	@media ( min-width: @min-width-breakpoint-desktop ) {
-		display: grid;
 		// stylelint-disable-next-line @stylistic/declaration-colon-space-after
 		grid-template-areas:
 			'searchform searchform'

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -101,6 +101,7 @@
 
 			.cdx-text-input {
 				min-width: auto;
+				flex-grow: 1;
 			}
 		}
 

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -140,8 +140,9 @@
 // TODO: Find a way to put .wikibase-faceted-search inside .searchresults
 .mw-body-content:has( .wikibase-faceted-search ) {
 	display: grid;
+	// stylelint-disable-next-line @stylistic/declaration-colon-space-after
 	grid-template-areas:
- 'searchform'
+ 		'searchform'
 		'sidebar'
 		'results';
 

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -142,7 +142,7 @@
 	display: grid;
 	// stylelint-disable-next-line @stylistic/declaration-colon-space-after
 	grid-template-areas:
- 		'searchform'
+		'searchform'
 		'sidebar'
 		'results';
 

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -1,6 +1,8 @@
 @import 'mediawiki.skin.variables.less';
 
 .wikibase-faceted-search {
+	margin-bottom: @spacing-100;
+
 	&__icon {
 		// Needed the specificity to override cdx-mixin-css-icon mixin
 		&.wikibase-faceted-search__icon {

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -1,10 +1,82 @@
 @import 'mediawiki.skin.variables.less';
 
 .wikibase-faceted-search {
+	&__icon {
+		// Needed the specificity to override cdx-mixin-css-icon mixin
+		&.wikibase-faceted-search__icon {
+			// Icon should always stay in sync with the current text color
+			background-color: currentcolor;
+		}
+
+		&--filter {
+			.cdx-mixin-css-icon( @cdx-icon-funnel );
+		}
+	}
+
+	// Header that is also used as collapse button in mobile
+	&__header {
+		display: none;
+
+		@media ( max-width: @max-width-breakpoint-tablet ) {
+			display: block;
+		}
+
+		// Style as a ToggleButton
+		// Because we are not using a <button> element, we have to
+		// insert the background, hover, and active states manually
+		> summary {
+			display: flex;
+			align-items: center;
+			max-width: none;
+			background-color: @background-color-interactive-subtle;
+			border-color: @border-color-base;
+			user-select: none;
+
+			&:hover {
+				// TODO: Use @background-color-interactive-subtle--hover when available in Codex
+				background-color: @background-color-base;
+				cursor: pointer;
+			}
+
+			&:active {
+				// TODO: Use @background-color-interactive-subtle--active when available in Codex
+				background-color: @background-color-interactive;
+				// TODO: Use @border-color-interactive--active when available in Codex
+				border-color: @border-color-interactive;
+				box-shadow: none;
+			}
+		}
+
+		&[ open ] > summary {
+			border-bottom-left-radius: 0;
+			border-bottom-right-radius: 0;
+			background-color: @background-color-progressive;
+			border-color: transparent;
+			color: @color-inverted-fixed;
+		}
+	}
+
 	// Common
 	&__facets {
 		position: sticky;
 		top: @spacing-100;
+
+		// Default to collapsed state in tablet
+		@media ( max-width: @max-width-breakpoint-tablet ) {
+			display: none;
+
+			.wikibase-faceted-search__header[ open ] + & {
+				display: block;
+				border-style: solid;
+				border-width: 1px;
+				border-color: @border-color-base;
+				margin-bottom: -1px;
+
+				.wikibase-faceted-search__facet:last-child {
+					border-bottom: 0;
+				}
+			}
+		}
 	}
 
 	// List facet
@@ -48,6 +120,17 @@
 			flex-shrink: 0;
 		}
 	}
+
+	.cdx-accordion {
+		&__content {
+			font-size: inherit;
+		}
+
+		.cdx-accordion__header {
+			font-size: inherit;
+			font-weight: @font-weight-bold;
+		}
+	}
 }
 
 // HACK: Creating a multi-column layout
@@ -55,7 +138,7 @@
 .mw-body-content:has( .wikibase-faceted-search ) {
 	display: grid;
 	grid-template-areas:
-		'searchform'
+ 'searchform'
 		'sidebar'
 		'results';
 

--- a/src/Presentation/FacetUiBuilder.php
+++ b/src/Presentation/FacetUiBuilder.php
@@ -36,7 +36,10 @@ class FacetUiBuilder {
 
 		return $this->parser->processTemplate(
 			'Facets',
-			[ 'facets' => $this->facetsToViewModel() ]
+			[
+				'msg-filters' => wfMessage( 'wikibase-faceted-search-filters' )->text(),
+				'facets' => $this->facetsToViewModel()
+			]
 		);
 	}
 

--- a/templates/Facets.mustache
+++ b/templates/Facets.mustache
@@ -1,4 +1,13 @@
 <div class="wikibase-faceted-search">
+	<details class="wikibase-faceted-search__header">
+		<summary class="cdx-button cdx-button--size-large">
+			<span
+				class="wikibase-faceted-search__icon wikibase-faceted-search__icon--filter cdx-button__icon"
+				aria-hidden="true"
+			></span>
+			{{msg-filters}}
+		</summary>
+	</details>
 	<div class="wikibase-faceted-search__facets">
 		{{#facets}}
 			{{!
@@ -7,9 +16,9 @@
 			}}
 			<details class="wikibase-faceted-search__facet cdx-accordion" {{#expanded}}open{{/expanded}}>
 				<summary>
-					<h3 class="cdx-accordion__header">
+					<div class="cdx-accordion__header">
 						<span class="cdx-accordion__header__title">{{label}}</span>
-					</h3>
+					</div>
 				</summary>
 				<div class="cdx-accordion__content">
 					{{{values-html}}}


### PR DESCRIPTION
Issue: #77

Key changes:
- Add a toggle button that is only visible for tablet viewport or below. The button can be used to expand/collapse the facets
- Make text input in range facet fill the whole container
- Move facet above the search results for tablet viewport or below
- Fix incorrect spacing in Chameleon

https://github.com/user-attachments/assets/52d0bdce-61e1-4d55-bb77-3c76fb3c6282

