### PR TITLE
Add placeholder And/Or toggle to facet UI

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,6 +18,9 @@
 
 	"wikibase-faceted-search-filters": "Filters",
 
+	"wikibase-faceted-search-and": "And",
+	"wikibase-faceted-search-or": "Or",
+
 	"wikibase-faceted-search-facet-range-min": "Minimum",
 	"wikibase-faceted-search-facet-range-max": "Maximum"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -13,6 +13,8 @@
 	"wikibase-faceted-search-config-help": "Help text heading displayed on \"MediaWiki:WikibaseFacetedSearch\"",
 	"wikibase-faceted-search-config-help-example": "Help text heading displayed on \"MediaWiki:WikibaseFacetedSearch\"",
 	"wikibase-faceted-search-filters": "Label used for the Filters button to toggle the facets",
+	"wikibase-faceted-search-and": "Label used for the And toggle button in the And/Or toggle",
+	"wikibase-faceted-search-or": "Label used for the Or toggle button in the And/Or toggle",
 	"wikibase-faceted-search-facet-range-min": "Minimum value label displayed on range facet",
 	"wikibase-faceted-search-facet-range-max": "Maximum value label displayed on range facet"
 }

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -15,6 +15,16 @@
 		}
 	}
 
+	&__cdx-button-link {
+		color: @color-base;
+
+		&:hover,
+		&:active,
+		&:visited {
+			color: @color-base;
+		}
+	}
+
 	// Use this class when we are not using a <button> element for cdx-button
 	// Because cdx-button styles rely on the :enabled and :disabled pseudo-classes,
 	// we have to insert the background, hover, and active states manually
@@ -82,6 +92,19 @@
 					border-bottom: 0;
 				}
 			}
+		}
+	}
+
+	&__facet-toggle {
+		margin-bottom: @spacing-100;
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		border-radius: @border-radius-base;
+		overflow: hidden;
+
+		.cdx-button {
+			border-radius: 0;
+			width: 100%;
 		}
 	}
 

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -5,7 +5,7 @@
 
 	&__icon {
 		// Needed the specificity to override cdx-mixin-css-icon mixin
-		&.wikibase-faceted-search__icon {
+		&.wikibase-faceted-search__icon.wikibase-faceted-search__icon.wikibase-faceted-search__icon {
 			// Icon should always stay in sync with the current text color
 			background-color: currentcolor;
 		}
@@ -22,28 +22,6 @@
 		&:active,
 		&:visited {
 			color: @color-base;
-		}
-	}
-
-	// Use this class when we are not using a <button> element for cdx-button
-	// Because cdx-button styles rely on the :enabled and :disabled pseudo-classes,
-	// we have to insert the background, hover, and active states manually
-	&__cdx-button {
-		background-color: @background-color-interactive-subtle;
-		border-color: @border-color-base;
-
-		&:hover {
-			// TODO: Use @background-color-interactive-subtle--hover when available in Codex
-			background-color: @background-color-base;
-			cursor: pointer;
-		}
-
-		&:active {
-			// TODO: Use @background-color-interactive-subtle--active when available in Codex
-			background-color: @background-color-interactive;
-			// TODO: Use @border-color-interactive--active when available in Codex
-			border-color: @border-color-interactive;
-			box-shadow: none;
 		}
 	}
 

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -15,6 +15,28 @@
 		}
 	}
 
+	// Use this class when we are not using a <button> element for cdx-button
+	// Because cdx-button styles rely on the :enabled and :disabled pseudo-classes,
+	// we have to insert the background, hover, and active states manually
+	&__cdx-button {
+		background-color: @background-color-interactive-subtle;
+		border-color: @border-color-base;
+
+		&:hover {
+			// TODO: Use @background-color-interactive-subtle--hover when available in Codex
+			background-color: @background-color-base;
+			cursor: pointer;
+		}
+
+		&:active {
+			// TODO: Use @background-color-interactive-subtle--active when available in Codex
+			background-color: @background-color-interactive;
+			// TODO: Use @border-color-interactive--active when available in Codex
+			border-color: @border-color-interactive;
+			box-shadow: none;
+		}
+	}
+
 	// Header that is also used as collapse button in mobile
 	&__header {
 		display: none;
@@ -24,29 +46,11 @@
 		}
 
 		// Style as a ToggleButton
-		// Because we are not using a <button> element, we have to
-		// insert the background, hover, and active states manually
 		> summary {
 			display: flex;
 			align-items: center;
 			max-width: none;
-			background-color: @background-color-interactive-subtle;
-			border-color: @border-color-base;
 			user-select: none;
-
-			&:hover {
-				// TODO: Use @background-color-interactive-subtle--hover when available in Codex
-				background-color: @background-color-base;
-				cursor: pointer;
-			}
-
-			&:active {
-				// TODO: Use @background-color-interactive-subtle--active when available in Codex
-				background-color: @background-color-interactive;
-				// TODO: Use @border-color-interactive--active when available in Codex
-				border-color: @border-color-interactive;
-				box-shadow: none;
-			}
 		}
 
 		&[ open ] > summary {

--- a/src/Presentation/FacetUiBuilder.php
+++ b/src/Presentation/FacetUiBuilder.php
@@ -38,6 +38,8 @@ class FacetUiBuilder {
 			'Facets',
 			[
 				'msg-filters' => wfMessage( 'wikibase-faceted-search-filters' )->text(),
+				'msg-and' => wfMessage( 'wikibase-faceted-search-and' )->text(),
+				'msg-or' => wfMessage( 'wikibase-faceted-search-or' )->text(),
 				'facets' => $this->facetsToViewModel()
 			]
 		);

--- a/src/Presentation/FacetUiBuilder.php
+++ b/src/Presentation/FacetUiBuilder.php
@@ -54,7 +54,8 @@ class FacetUiBuilder {
 				'values-html' => $this->getItemsHtml(
 					$this->getExampleListItems(), FacetType::LIST->value, 'Author'
 				),
-				'expanded' => true
+				'expanded' => true,
+				'hasToggle' => true
 			],
 			[
 				'label' => 'Year',
@@ -62,7 +63,8 @@ class FacetUiBuilder {
 				'values-html' => $this->getItemsHtml(
 					[ $this->getExampleRangeItems()[0] ], FacetType::RANGE->value, 'Year'
 				),
-				'expanded' => true
+				'expanded' => true,
+				'hasToggle' => false
 			],
 			[
 				'label' => 'Pages',
@@ -70,7 +72,8 @@ class FacetUiBuilder {
 				'values-html' => $this->getItemsHtml(
 					[ $this->getExampleRangeItems()[1] ], FacetType::RANGE->value, 'Pages'
 				),
-				'expanded' => false
+				'expanded' => false,
+				'hasToggle' => false
 			]
 		];
 	}

--- a/templates/Facet.mustache
+++ b/templates/Facet.mustache
@@ -9,6 +9,7 @@
 		</div>
 	</summary>
 	<div class="cdx-accordion__content">
+		{{#hasToggle}}{{>FacetToggle}}{{/hasToggle}}
 		{{{values-html}}}
 	</div>
 </details>

--- a/templates/Facet.mustache
+++ b/templates/Facet.mustache
@@ -1,0 +1,14 @@
+{{!
+	Codex - Accordion component
+	@see https://doc.wikimedia.org/codex/v1.14.0/components/demos/accordion.html#markup-structure
+}}
+<details class="wikibase-faceted-search__facet cdx-accordion" {{#expanded}}open{{/expanded}}>
+	<summary>
+		<div class="cdx-accordion__header">
+			<span class="cdx-accordion__header__title">{{label}}</span>
+		</div>
+	</summary>
+	<div class="cdx-accordion__content">
+		{{{values-html}}}
+	</div>
+</details>

--- a/templates/FacetToggle.mustache
+++ b/templates/FacetToggle.mustache
@@ -1,8 +1,8 @@
 <div class="wikibase-faceted-search__facet-toggle">
 	<a class="wikibase-faceted-search__cdx-button-link" href="">
-		<button class="cdx-button cdx-button--action-progressive cdx-button--weight-primary">And</button>
+		<button class="cdx-button cdx-button--action-progressive cdx-button--weight-primary">{{msg-and}}</button>
 	</a>
 	<a class="wikibase-faceted-search__cdx-button-link" href="">
-		<button class="cdx-button" disabled>Or</button>
+		<button class="cdx-button" disabled>{{msg-or}}</button>
 	</a>
 </div>

--- a/templates/FacetToggle.mustache
+++ b/templates/FacetToggle.mustache
@@ -1,0 +1,8 @@
+<div class="wikibase-faceted-search__facet-toggle">
+	<a class="wikibase-faceted-search__cdx-button-link" href="">
+		<button class="cdx-button cdx-button--action-progressive cdx-button--weight-primary">And</button>
+	</a>
+	<a class="wikibase-faceted-search__cdx-button-link" href="">
+		<button class="cdx-button" disabled>Or</button>
+	</a>
+</div>

--- a/templates/Facets.mustache
+++ b/templates/Facets.mustache
@@ -1,6 +1,6 @@
 <div class="wikibase-faceted-search">
 	<details class="wikibase-faceted-search__header">
-		<summary class="wikibase-faceted-search__cdx-button cdx-button--size-large">
+		<summary class="wikibase-faceted-search__cdx-button cdx-button cdx-button--size-large">
 			<span
 				class="wikibase-faceted-search__icon wikibase-faceted-search__icon--filter cdx-button__icon"
 				aria-hidden="true"

--- a/templates/Facets.mustache
+++ b/templates/Facets.mustache
@@ -9,21 +9,6 @@
 		</summary>
 	</details>
 	<div class="wikibase-faceted-search__facets">
-		{{#facets}}
-			{{!
-				Codex - Accordion component
-				@see https://doc.wikimedia.org/codex/v1.14.0/components/demos/accordion.html#markup-structure
-			}}
-			<details class="wikibase-faceted-search__facet cdx-accordion" {{#expanded}}open{{/expanded}}>
-				<summary>
-					<div class="cdx-accordion__header">
-						<span class="cdx-accordion__header__title">{{label}}</span>
-					</div>
-				</summary>
-				<div class="cdx-accordion__content">
-					{{{values-html}}}
-				</div>
-			</details>
-		{{/facets}}
+		{{#facets}}{{>Facet}}{{/facets}}
 	</div>
 </div>

--- a/templates/Facets.mustache
+++ b/templates/Facets.mustache
@@ -1,6 +1,6 @@
 <div class="wikibase-faceted-search">
 	<details class="wikibase-faceted-search__header">
-		<summary class="cdx-button cdx-button--size-large">
+		<summary class="wikibase-faceted-search__cdx-button cdx-button--size-large">
 			<span
 				class="wikibase-faceted-search__icon wikibase-faceted-search__icon--filter cdx-button__icon"
 				aria-hidden="true"

--- a/templates/Facets.mustache
+++ b/templates/Facets.mustache
@@ -1,6 +1,6 @@
 <div class="wikibase-faceted-search">
 	<details class="wikibase-faceted-search__header">
-		<summary class="wikibase-faceted-search__cdx-button cdx-button cdx-button--size-large">
+		<summary class="cdx-button cdx-button--size-large cdx-button--fake-button cdx-button--fake-button--enabled">
 			<span
 				class="wikibase-faceted-search__icon wikibase-faceted-search__icon--filter cdx-button__icon"
 				aria-hidden="true"


### PR DESCRIPTION
Key changes
- Add And/Or toggle to list facets. Each button is set up as an `<a>` element so that it can be used to trigger a page load
- Move Facet out of `Facets.mustache` into a new template `Facet.mustache` for cleaner organization
- Use Codex built-in `cdx-button--fake-button` classes directly to style Codex buttons that are not `<button>`

![image](https://github.com/user-attachments/assets/defd77ac-b473-4ea8-b653-70195b2aaf7e)
