### PR TITLE
Remove anchor element from Facet UI

### DIFF
--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -15,16 +15,6 @@
 		}
 	}
 
-	&__cdx-button-link {
-		color: @color-base;
-
-		&:hover,
-		&:active,
-		&:visited {
-			color: @color-base;
-		}
-	}
-
 	// Header that is also used as collapse button in mobile
 	&__header {
 		display: none;
@@ -100,19 +90,6 @@
 		.cdx-label__label__text {
 			display: flex;
 			align-items: center;
-		}
-
-		&-link {
-			// There are many unpredicable styles from different skins in MW
-			// stylelint-disable declaration-no-important
-			color: inherit !important;
-			text-decoration: none !important;
-			// stylelint-enable declaration-no-important
-			cursor: pointer;
-
-			> * {
-				pointer-events: none;
-			}
 		}
 
 		&-range {

--- a/src/Presentation/ListFacetHtmlBuilder.php
+++ b/src/Presentation/ListFacetHtmlBuilder.php
@@ -51,8 +51,6 @@ class ListFacetHtmlBuilder implements FacetHtmlBuilder {
 				'label' => $valueCount->value,
 				'count' => $valueCount->count, // FIXME: count is now showing in the UI for some reason
 				'checked' => in_array( $valueCount->value, $selectedValues ), // TODO: test with multiple types of values
-				'link' => 'TODO', // TODO: remove link. Perhaps add some data-attribute (though currently "label" already gets the value)
-
 				// TODO: can't we escape this in the template?
 				// https://github.com/ProfessionalWiki/WikibaseFacetedSearch/pull/95#discussion_r1912980729
 				'id' => Sanitizer::escapeIdForAttribute( htmlspecialchars( $state->propertyId->getSerialization() . "-$i" ) ),

--- a/templates/ListFacet.mustache
+++ b/templates/ListFacet.mustache
@@ -1,41 +1,33 @@
 {{#hasToggle}}
 	<div class="wikibase-faceted-search__facet-toggle">
-		<a class="wikibase-faceted-search__cdx-button-link" href="">
-			<button class="cdx-button cdx-button--action-progressive cdx-button--weight-primary">
-				{{msg-and}}
-			</button>
-		</a>
-		<a class="wikibase-faceted-search__cdx-button-link" href="">
-			<button class="cdx-button">
-				{{msg-or}}
-			</button>
-		</a>
+		<button class="cdx-button cdx-button--action-progressive cdx-button--weight-primary">
+			{{msg-and}}
+		</button>
+		<button class="cdx-button">
+			{{msg-or}}
+		</button>
 	</div>
 {{/hasToggle}}
 
 {{#checkboxes}}
 	<div
 		class="wikibase-faceted-search__facet-item wikibase-faceted-search__facet-item-checkbox cdx-checkbox">
-		<a class="wikibase-faceted-search__facet-item-link" href="{{link}}">
-
-			<div class="cdx-checkbox__wrapper">
-				<input
-					id="{{id}}"
-					class="cdx-checkbox__input"
-					type="checkbox"
-					{{#checked}}checked{{/checked}}
-					{{! Prevent input from being interacted by keyboard}}
-					tabindex="-1"
-				/>
-				<span class="cdx-checkbox__icon"></span>
-				<div class="cdx-checkbox__label cdx-label">
-					<label class="cdx-label__label" for="{{id}}">
-						{{! Change to <div> tag instead of <span> tag for valid HTML }}
-						<span class="cdx-label__label__text">{{>FacetItemLabel}}</span>
-					</label>
-				</div>
+		<div class="cdx-checkbox__wrapper">
+			<input
+				id="{{id}}"
+				class="cdx-checkbox__input"
+				type="checkbox"
+				{{#checked}}checked{{/checked}}
+				{{! Prevent input from being interacted by keyboard}}
+				tabindex="-1"
+			/>
+			<span class="cdx-checkbox__icon"></span>
+			<div class="cdx-checkbox__label cdx-label">
+				<label class="cdx-label__label" for="{{id}}">
+					{{! Change to <div> tag instead of <span> tag for valid HTML }}
+					<span class="cdx-label__label__text">{{>FacetItemLabel}}</span>
+				</label>
 			</div>
-
-		</a>
+		</div>
 	</div>
 {{/checkboxes}}

--- a/templates/ListFacet.mustache
+++ b/templates/ListFacet.mustache
@@ -18,13 +18,10 @@
 				class="cdx-checkbox__input"
 				type="checkbox"
 				{{#checked}}checked{{/checked}}
-				{{! Prevent input from being interacted by keyboard}}
-				tabindex="-1"
 			/>
 			<span class="cdx-checkbox__icon"></span>
 			<div class="cdx-checkbox__label cdx-label">
 				<label class="cdx-label__label" for="{{id}}">
-					{{! Change to <div> tag instead of <span> tag for valid HTML }}
 					<span class="cdx-label__label__text">{{>FacetItemLabel}}</span>
 				</label>
 			</div>


### PR DESCRIPTION
We don't need them anymore because we are handling interaction in JS instead of URLs