### PR TITLE
Support facet type specific config

### DIFF
--- a/src/Application/Config.php
+++ b/src/Application/Config.php
@@ -44,4 +44,8 @@ class Config {
 		return $this->getFacets()->getFacetConfigForInstanceType( $instanceTypeId )->asArray();
 	}
 
+	public function getConfigForProperty( ItemId $instanceTypeId, PropertyId $propertyId ): ?FacetConfig {
+		return $this->getFacets()->getFacetConfigForInstanceType( $instanceTypeId )->getConfigForProperty( $propertyId );
+	}
+
 }

--- a/src/Application/FacetConfig.php
+++ b/src/Application/FacetConfig.php
@@ -9,11 +9,14 @@ use Wikibase\DataModel\Entity\PropertyId;
 
 class FacetConfig {
 
+	/**
+	 * @param array<string, mixed> $typeSpecificConfig
+	 */
 	public function __construct(
 		public readonly ItemId $instanceTypeId,
 		public readonly PropertyId $propertyId,
 		public readonly FacetType $type,
-		// TODO: type specific config array
+		public readonly array $typeSpecificConfig = [],
 	) {
 	}
 

--- a/src/Application/FacetConfigList.php
+++ b/src/Application/FacetConfigList.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseFacetedSearch\Application;
 
 use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\PropertyId;
 
 class FacetConfigList {
 
@@ -31,6 +32,16 @@ class FacetConfigList {
 	 */
 	public function asArray(): array {
 		return $this->facets;
+	}
+
+	public function getConfigForProperty( PropertyId $propertyId ): ?FacetConfig {
+		foreach ( $this->facets as $facetConfig ) {
+			if ( $facetConfig->propertyId->equals( $propertyId ) ) {
+				return $facetConfig;
+			}
+		}
+
+		return null;
 	}
 
 }

--- a/src/Persistence/ConfigDeserializer.php
+++ b/src/Persistence/ConfigDeserializer.php
@@ -71,14 +71,17 @@ class ConfigDeserializer {
 	}
 
 	/**
-	 * TODO: defaultCombineWith, allowCombineWithChoice, showNoneFilter, showAnyFilter
 	 * @param array<string, mixed> $facetConfig
 	 */
 	private function newFacetConfig( string $itemId, string $propertyId, array $facetConfig ): FacetConfig {
+		$typeSpecificConfig = $facetConfig;
+		unset( $typeSpecificConfig['type'] );
+
 		return new FacetConfig(
 			instanceTypeId: new ItemId( $itemId ),
 			propertyId: new NumericPropertyId( $propertyId ),
-			type: FacetType::from( $facetConfig['type'] )
+			type: FacetType::from( $facetConfig['type'] ),
+			typeSpecificConfig: $typeSpecificConfig
 		);
 	}
 

--- a/tests/Application/ConfigTest.php
+++ b/tests/Application/ConfigTest.php
@@ -6,12 +6,16 @@ namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Application;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\FacetConfig;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\FacetConfigList;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\FacetType;
 use RuntimeException;
+use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\NumericPropertyId;
 
 /**
  * @covers \ProfessionalWiki\WikibaseFacetedSearch\Application\Config
+ * @covers \ProfessionalWiki\WikibaseFacetedSearch\Application\FacetConfigList
  */
 class ConfigTest extends TestCase {
 
@@ -69,6 +73,51 @@ class ConfigTest extends TestCase {
 		$config = new Config( facets: $facets );
 
 		$this->assertSame( $facets, $config->getFacets() );
+	}
+
+	public function testGetConfigForPropertyReturnsNullOnNotFound(): void {
+		$this->assertNull(
+			( new Config() )->getConfigForProperty( new ItemId( 'Q404' ), new NumericPropertyId( 'P404' ) )
+		);
+	}
+
+	public function testGetConfigForPropertyReturnsConfigForTheRightItemAndPropertyIdCombo(): void {
+		$twoTwoHundredFacet = new FacetConfig(
+			instanceTypeId: new ItemId( 'Q2' ),
+			propertyId: new NumericPropertyId( 'P200' ),
+			type: FacetType::RANGE
+		);
+
+		$config = new Config(
+			facets: new FacetConfigList(
+				new FacetConfig(
+					instanceTypeId: new ItemId( 'Q1' ),
+					propertyId: new NumericPropertyId( 'P200' ),
+					type: FacetType::RANGE
+				),
+				new FacetConfig(
+					instanceTypeId: new ItemId( 'Q2' ),
+					propertyId: new NumericPropertyId( 'P100' ),
+					type: FacetType::RANGE
+				),
+				$twoTwoHundredFacet,
+				new FacetConfig(
+					instanceTypeId: new ItemId( 'Q3' ),
+					propertyId: new NumericPropertyId( 'P200' ),
+					type: FacetType::RANGE
+				),
+				new FacetConfig(
+					instanceTypeId: new ItemId( 'Q2' ),
+					propertyId: new NumericPropertyId( 'P300' ),
+					type: FacetType::RANGE
+				)
+			)
+		);
+
+		$this->assertEquals(
+			$twoTwoHundredFacet,
+			$config->getConfigForProperty( new ItemId( 'Q2' ), new NumericPropertyId( 'P200' ) )
+		);
 	}
 
 }


### PR DESCRIPTION
This is needed so we can access these config in ListFacetHtmlBuilder: defaultCombineWith, allowCombineWithChoice, showNoneFilter, showAnyFilter. 

Config refactor not included. Looks like we can keep the issues as prudent technical debt. Tracked with
* https://github.com/ProfessionalWiki/WikibaseFacetedSearch/issues/107

