### PR TITLE
Drop Codex Radio component

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -85,7 +85,6 @@
 				"CdxButton",
 				"CdxCheckbox",
 				"CdxField",
-				"CdxRadio",
 				"CdxTextInput"
 			]
 		},


### PR DESCRIPTION
Follow-up to #109

Since we drop FacetRadio, the Codex Radio component is not used anymore and we can safely drop it.