### PR TITLE
Make instance tabs functional

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,6 +67,12 @@ parameters:
 			path: src/Presentation/UiBuilder.php
 
 		-
+			message: '#^Method ProfessionalWiki\\WikibaseFacetedSearch\\Presentation\\UiBuilder\:\:renderTemplate\(\) has parameter \$instancesViewModel with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Presentation/UiBuilder.php
+
+		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
 			count: 1

--- a/resources/ext.wikibase.facetedsearch.js
+++ b/resources/ext.wikibase.facetedsearch.js
@@ -4,14 +4,19 @@ let specialSearchInput;
  * Main entry point for the JavaScript code.
  */
 function init() {
-	const facets = document.querySelector( '.wikibase-faceted-search__facets' );
-	if ( !facets ) {
+	specialSearchInput = document.querySelector( '#searchText > input' );
+	if ( !specialSearchInput ) {
 		return;
 	}
 
-	specialSearchInput = document.querySelector( '#searchText > input' );
-
-	facets.addEventListener( 'input', onFacetsInput );
+	const facets = document.querySelector( '.wikibase-faceted-search__facets' );
+	const instances = document.querySelector( '.wikibase-faceted-search__instances' );
+	if ( facets ) {
+		facets.addEventListener( 'input', onFacetsInput );
+	}
+	if ( instances ) {
+		instances.addEventListener( 'click', ( event ) => onInstancesClick( event, instances.dataset.instanceId ) );
+	}
 }
 
 /**
@@ -40,6 +45,22 @@ function onFacetsInput( event ) {
 	} else if ( input.classList.contains( 'cdx-text-input__input' ) ) {
 		onRangeFacetInput( facet, propertyId );
 	}
+}
+
+function onInstancesClick( event, instanceId ) {
+	if ( !event.target ) {
+		return;
+	}
+
+	const instance = event.target.closest( '.wikibase-faceted-search__instance' );
+	if ( !instance ) {
+		return;
+	}
+
+	submitSearchForm( buildQueryString(
+		specialSearchInput.value,
+		[ instance.value ? `haswbstatement:${ instanceId }=${ instance.value }` : '' ]
+	) );
 }
 
 /**
@@ -126,11 +147,11 @@ function getRangeFacetQueries( minInput, maxInput, propertyId ) {
 /**
  * Builds a new query string from the given old query and facet.
  *
- * @param {string} oldQuery The original query string.
- * @param {Array} newQueries The new queries to add.
- * @param {string} propertyId The property ID to filter out.
+ * @param {string} oldQuery
+ * @param {Array} newQueries
+ * @param {?string} propertyId
  *
- * @return {string} The new query string.
+ * @return {string}
  */
 function buildQueryString( oldQuery, newQueries, propertyId ) {
 	const queries = getFilteredQueries( oldQuery, propertyId );
@@ -139,16 +160,18 @@ function buildQueryString( oldQuery, newQueries, propertyId ) {
 }
 
 /**
- * Filters out queries that already include the given property ID
+ * Filters out wbfs queries that already include the given property ID
+ * Remove all wbfs queries if no property ID is given
  *
- * @param {string} query The query string to filter.
- * @param {string} propertyId The property ID to filter out.
+ * @param {string} query
+ * @param {?string} propertyId
  *
- * @return {string[]} The filtered queries.
+ * @return {string[]}
  */
 function getFilteredQueries( query, propertyId ) {
+	const propertyIdPattern = propertyId || 'P\\d+';
 	return query.split( /\s+/ ).filter(
-		( item ) => !new RegExp( `^(haswbfacet|\\-haswbfacet):${ propertyId }(=|>=|<=)` ).test( item )
+		( item ) => !( new RegExp( `^(haswbfacet|\\-haswbfacet|haswbstatement):${ propertyIdPattern }(=|>=|<=)` ) ).test( item )
 	);
 }
 
@@ -158,7 +181,7 @@ function getFilteredQueries( query, propertyId ) {
  * @param {string} query The query to add to/remove from the search form.
  */
 function submitSearchForm( query ) {
-	specialSearchInput.value = query;
+	specialSearchInput.value = query.trim();
 	// Submit the search form
 	specialSearchInput.form.submit();
 }

--- a/src/Application/Query.php
+++ b/src/Application/Query.php
@@ -8,6 +8,9 @@ use Wikibase\DataModel\Entity\PropertyId;
 
 class Query {
 
+	/**
+	 * @param ItemId[] $itemTypes
+	 */
 	public function __construct(
 		public readonly PropertyConstraintsList $constraints,
 		private readonly string $freeText = '',

--- a/src/Application/Query.php
+++ b/src/Application/Query.php
@@ -4,14 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\Application;
 
-use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\PropertyId;
 
 class Query {
 
-	/**
-	 * @param array<string, NumericPropertyId|ItemId>|array $instance
-	 */
 	public function __construct(
 		public readonly PropertyConstraintsList $constraints,
 		private readonly string $freeText = '',

--- a/src/Application/Query.php
+++ b/src/Application/Query.php
@@ -15,7 +15,7 @@ class Query {
 	public function __construct(
 		public readonly PropertyConstraintsList $constraints,
 		private readonly string $freeText = '',
-		private readonly array $instance = []
+		private readonly array $itemTypes = []
 	) {
 	}
 
@@ -34,12 +34,8 @@ class Query {
 		return $this->freeText;
 	}
 
-	public function getInstancePropertyId(): ?PropertyId {
-		return $this->instance['propertyId'] ?? null;
-	}
-
-	public function getInstanceItemId(): ?ItemId {
-		return $this->instance['itemId'] ?? null;
+	public function getInstanceItemTypes(): array {
+		return $this->itemTypes;
 	}
 
 }

--- a/src/Application/Query.php
+++ b/src/Application/Query.php
@@ -4,13 +4,15 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\Application;
 
+use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\PropertyId;
 
 class Query {
 
 	public function __construct(
 		public readonly PropertyConstraintsList $constraints,
-		private readonly string $freeText = ''
+		private readonly string $freeText = '',
+		private readonly array $instance = []
 	) {
 	}
 
@@ -27,6 +29,14 @@ class Query {
 
 	public function getFreeText(): string {
 		return $this->freeText;
+	}
+
+	public function getInstancePropertyId(): ?PropertyId {
+		return $this->instance['propertyId'] ?? null;
+	}
+
+	public function getInstanceItemId(): ?ItemId {
+		return $this->instance['itemId'] ?? null;
 	}
 
 }

--- a/src/Application/Query.php
+++ b/src/Application/Query.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\Application;
 
+use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\PropertyId;
 
 class Query {

--- a/src/Application/Query.php
+++ b/src/Application/Query.php
@@ -9,6 +9,9 @@ use Wikibase\DataModel\Entity\PropertyId;
 
 class Query {
 
+	/**
+	 * @param array<string, NumericPropertyId|ItemId>|array $instance
+	 */
 	public function __construct(
 		public readonly PropertyConstraintsList $constraints,
 		private readonly string $freeText = '',

--- a/src/Application/QueryStringParser.php
+++ b/src/Application/QueryStringParser.php
@@ -52,6 +52,10 @@ class QueryStringParser {
 			|| str_starts_with( $part, '-haswbfacet:' );
 	}
 
+	/**
+	 * @param array<string, NumericPropertyId|ItemId> $instance
+	 * @return array<string, NumericPropertyId|ItemId>
+	 */
 	private function handleInstancePart( string $part, array &$instance ): array {
 		$part = substr( $part, strlen( 'haswbstatement:' ) );
 		[ $propertyIdString, $itemIdString ] = explode( '=', $part, 2 );

--- a/src/Application/QueryStringParser.php
+++ b/src/Application/QueryStringParser.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\Application;
 
+use InvalidArgumentException;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\NumericPropertyId;
 
@@ -64,8 +65,12 @@ class QueryStringParser {
 			return [];
 		}
 
-		$instance['propertyId'] = new NumericPropertyId( $propertyIdString );
-		$instance['itemId'] = new ItemId( $itemIdString ); // TODO: Support non-item id values
+		try {
+			$instance['propertyId'] = new NumericPropertyId( $propertyIdString );
+			$instance['itemId'] = new ItemId( $itemIdString );
+		} catch ( InvalidArgumentException ) {
+			return [];
+		}
 
 		return $instance;
 	}

--- a/src/Presentation/UiBuilder.php
+++ b/src/Presentation/UiBuilder.php
@@ -10,6 +10,7 @@ use ProfessionalWiki\WikibaseFacetedSearch\Application\FacetConfig;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraints;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\Query;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\QueryStringParser;
+use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Entity\ItemId;
 
 class UiBuilder {
@@ -26,19 +27,27 @@ class UiBuilder {
 	 * TODO: add integration tests
 	 */
 	public function createHtml( string $searchQuery ): string {
+		$query = $this->parseQuery( $searchQuery );
+		$itemType = $query->getInstanceItemId();
+
 		return $this->renderTemplate(
+			$this->buildInstancesViewModel(
+				instanceId: $query->getInstancePropertyId(),
+				itemType: $itemType
+			),
 			$this->buildFacetsViewModel(
-				itemType: new ItemId( 'Q5976449' ), // TODO: get from search string
-				query: $this->parseQuery( $searchQuery )
+				itemType: $itemType,
+				query: $query
 			)
 		);
 	}
 
-	private function renderTemplate( array $facetsViewModel ): string {
+	private function renderTemplate( array $instancesViewModel, array $facetsViewModel ): string {
 		return $this->templateParser->processTemplate(
 			'Layout',
 			[
-				'instances' => $this->buildInstancesViewModel(),
+				'instanceId' => 'P1460', // TODO: Link to config
+				'instances' => $instancesViewModel,
 				'facets' => $facetsViewModel,
 				'msg-filters' => wfMessage( 'wikibase-faceted-search-filters' )->text(),
 			]
@@ -52,29 +61,43 @@ class UiBuilder {
 	/**
 	 * @return array<array<string, string>>
 	 */
-	private function buildInstancesViewModel(): array {
-		// TODO: Get instances from config
-		// TODO: Get currently selected instance from query
-		return [
+	private function buildInstancesViewModel( ?PropertyId $instanceId, ?ItemId $itemType ): array {
+		$instances = [
 			[
 				'label' => wfMessage( 'wikibase-faceted-search-instance-type-all' )->text(),
-				'value' => '',
-				'selected' => 'true'
-			],
-			[
-				'label' => 'Memes',
-				'value' => 'Q100',
-				'selected' => 'false'
-			],
-			[
-				'label' => 'Cat Pictures',
-				'value' => 'Q200',
-				'selected' => 'false'
+				'value' => ''
 			]
 		];
+
+		// TODO: Get instances from config
+		$instancesExample = [
+			[
+				'label' => 'People',
+				'value' => 'Q5976445'
+			],
+			[
+				'label' => 'Documents',
+				'value' => 'Q5976449'
+			]
+		];
+
+		$instances = array_merge( $instances, $instancesExample );
+
+		$itemTypeStr = $itemType ? $itemType->getSerialization() : '';
+		$instances = array_map( function( array $instance ) use ( $itemTypeStr )	 {
+			$instance['selected'] = $instance['value'] === $itemTypeStr ? 'true' : 'false';
+			return $instance;
+		}, $instances );
+
+		// TODO: Get currently selected instance from query
+		return $instances;
 	}
 
-	private function buildFacetsViewModel( ItemId $itemType, Query $query ): array {
+	private function buildFacetsViewModel( ?ItemId $itemType, Query $query ): array {
+		if ( $itemType === null ) {
+			return [];
+		}
+
 		$facets = [];
 
 		foreach ( $this->config->getFacetConfigForInstanceType( $itemType ) as $facetConfig ) {

--- a/src/Presentation/UiBuilder.php
+++ b/src/Presentation/UiBuilder.php
@@ -28,15 +28,15 @@ class UiBuilder {
 	 */
 	public function createHtml( string $searchQuery ): string {
 		$query = $this->parseQuery( $searchQuery );
-		$itemType = $query->getInstanceItemId();
+		$instanceItemId = $query->getInstanceItemId();
 
 		return $this->renderTemplate(
 			$this->buildInstancesViewModel(
-				instanceId: $query->getInstancePropertyId(),
-				itemType: $itemType
+				instancePropertyId: $query->getInstancePropertyId(),
+				instanceItemId: $instanceItemId
 			),
 			$this->buildFacetsViewModel(
-				itemType: $itemType,
+				instanceItemId: $instanceItemId,
 				query: $query
 			)
 		);
@@ -61,7 +61,7 @@ class UiBuilder {
 	/**
 	 * @return array<array<string, string>>
 	 */
-	private function buildInstancesViewModel( ?PropertyId $instanceId, ?ItemId $itemType ): array {
+	private function buildInstancesViewModel( ?PropertyId $instancePropertyId, ?ItemId $instanceItemId ): array {
 		$instances = [
 			[
 				'label' => wfMessage( 'wikibase-faceted-search-instance-type-all' )->text(),
@@ -83,9 +83,9 @@ class UiBuilder {
 
 		$instances = array_merge( $instances, $instancesExample );
 
-		$itemTypeStr = $itemType ? $itemType->getSerialization() : '';
-		$instances = array_map( function( array $instance ) use ( $itemTypeStr )	 {
-			$instance['selected'] = $instance['value'] === $itemTypeStr ? 'true' : 'false';
+		$instanceItemIdStr = $instanceItemId ? $instanceItemId->getSerialization() : '';
+		$instances = array_map( function( array $instance ) use ( $instanceItemIdStr )	 {
+			$instance['selected'] = $instance['value'] === $instanceItemIdStr ? 'true' : 'false';
 			return $instance;
 		}, $instances );
 
@@ -93,14 +93,14 @@ class UiBuilder {
 		return $instances;
 	}
 
-	private function buildFacetsViewModel( ?ItemId $itemType, Query $query ): array {
-		if ( $itemType === null ) {
+	private function buildFacetsViewModel( ?ItemId $instanceItemId, Query $query ): array {
+		if ( $instanceItemId === null ) {
 			return [];
 		}
 
 		$facets = [];
 
-		foreach ( $this->config->getFacetConfigForInstanceType( $itemType ) as $facetConfig ) {
+		foreach ( $this->config->getFacetConfigForInstanceType( $instanceItemId ) as $facetConfig ) {
 			$facets[] = $this->buildFacetViewModel(
 				$facetConfig,
 				$query->getConstraintsForProperty( $facetConfig->propertyId ) ?? new PropertyConstraints( $facetConfig->propertyId )

--- a/src/WikibaseFacetedSearchExtension.php
+++ b/src/WikibaseFacetedSearchExtension.php
@@ -206,7 +206,9 @@ class WikibaseFacetedSearchExtension {
 	}
 
 	private function getQueryStringParser(): QueryStringParser {
-		return new QueryStringParser();
+		return new QueryStringParser(
+			instanceType: $this->getConfig()->getInstanceOfId()
+		);
 	}
 
 }

--- a/templates/Topbar.mustache
+++ b/templates/Topbar.mustache
@@ -2,12 +2,12 @@
 	Codex - Tabs component
 	@see https://doc.wikimedia.org/codex/v1.14.0/components/demos/tabs.html#markup-structure
 }}
-<div class="cdx-tabs">
+<div class="wikibase-faceted-search__instances cdx-tabs" data-instance-id="{{instanceId}}">
 	<div class="cdx-tabs__header">
 		<div class="cdx-tabs__list" tabindex="-1">
 			{{#instances}}
 				<button
-					class="cdx-tabs__list__item"
+					class="wikibase-faceted-search__instance cdx-tabs__list__item"
 					aria-selected="{{selected}}"
 					value="{{value}}"
 				>

--- a/tests/phpunit/Application/QueryStringParserTest.php
+++ b/tests/phpunit/Application/QueryStringParserTest.php
@@ -162,7 +162,7 @@ class QueryStringParserTest extends TestCase {
 	private function newQueryStringParser(): QueryStringParser {
 		return new QueryStringParser(
 			instanceType: ( new Config(
-				instanceOfId: new NumericPropertyId( INSTANCE_TYPE_ID )
+				instanceOfId: new NumericPropertyId( self::INSTANCE_TYPE_ID )
 			) )->getInstanceOfId()
 		);
 	}

--- a/tests/phpunit/Application/QueryStringParserTest.php
+++ b/tests/phpunit/Application/QueryStringParserTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Application;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\QueryStringParser;
+use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\NumericPropertyId;
 
 /**
@@ -47,6 +48,17 @@ class QueryStringParserTest extends TestCase {
 		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
 
 		$this->assertTrue( $constraints->hasNoValue() );
+	}
+
+	public function testParsesInstance(): void {
+		$parser = new QueryStringParser();
+		$query = $parser->parse( 'haswbstatement:P42=Q68' );
+
+		$propertyId = new NumericPropertyId( 'P42' );
+		$itemId = new ItemId( 'Q68' );
+
+		$this->assertEquals( $propertyId, $query->getInstancePropertyId() );
+		$this->assertEquals( $itemId, $query->getInstanceItemId() );
 	}
 
 	public function testParsesAndValues(): void {

--- a/tests/phpunit/Application/QueryStringParserTest.php
+++ b/tests/phpunit/Application/QueryStringParserTest.php
@@ -64,6 +64,24 @@ class QueryStringParserTest extends TestCase {
 		$this->assertEquals( $itemTypes, $query->getInstanceItemTypes() );
 	}
 
+	public function testParsesNonExistenceItemTypes(): void {
+		$parser = $this->newQueryStringParser();
+		$query = $parser->parse( 'haswbfacet:P42' );
+
+		$this->assertEquals( [], $query->getInstanceItemTypes() );
+	}
+
+	public function testIgnoresHaswbstatementForNonInstanceOfIdProperties(): void {
+		$parser = $this->newQueryStringParser();
+		$query = $parser->parse( 'haswbstatement:P1=wrongId haswbstatement:' . self::INSTANCE_TYPE_ID . '=Q68 haswbstatement:P2=alsoWrong' );
+
+		$itemTypes = [
+			new ItemId( 'Q68' )
+		];
+
+		$this->assertEquals( $itemTypes, $query->getInstanceItemTypes() );
+	}
+
 	public function testParsesAndValues(): void {
 		$parser = $this->newQueryStringParser();
 		$query = $parser->parse( 'haswbfacet:P42=foo haswbfacet:P42=bar' );
@@ -161,9 +179,13 @@ class QueryStringParserTest extends TestCase {
 
 	private function newQueryStringParser(): QueryStringParser {
 		return new QueryStringParser(
-			instanceType: ( new Config(
-				instanceOfId: new NumericPropertyId( self::INSTANCE_TYPE_ID )
-			) )->getInstanceOfId()
+			instanceType: $this->newConfig()->getInstanceOfId()
+		);
+	}
+
+	private function newConfig(): Config {
+		return new Config(
+			instanceOfId: new NumericPropertyId( self::INSTANCE_TYPE_ID )
 		);
 	}
 

--- a/tests/phpunit/Application/QueryStringParserTest.php
+++ b/tests/phpunit/Application/QueryStringParserTest.php
@@ -14,13 +14,15 @@ use Wikibase\DataModel\Entity\NumericPropertyId;
  */
 class QueryStringParserTest extends TestCase {
 
+	private const INSTANCE_TYPE_ID = 'P90';
+
 	/**
 	 * @dataProvider freeTextProvider
 	 */
 	public function testParsesFreeText( string $queryString, string $expectedFreeText ): void {
 		$this->assertSame(
 			$expectedFreeText,
-			( new QueryStringParser() )->parse( $queryString )->getFreeText()
+			( $this->newQueryStringParser() )->parse( $queryString )->getFreeText()
 		);
 	}
 
@@ -33,7 +35,7 @@ class QueryStringParserTest extends TestCase {
 	}
 
 	public function testParsesExistenceConstraint(): void {
-		$parser = new QueryStringParser();
+		$parser = $this->newQueryStringParser();
 		$query = $parser->parse( 'haswbfacet:P42' );
 
 		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
@@ -42,7 +44,7 @@ class QueryStringParserTest extends TestCase {
 	}
 
 	public function testParsesNonExistenceConstraint(): void {
-		$parser = new QueryStringParser();
+		$parser = $this->newQueryStringParser();
 		$query = $parser->parse( '-haswbfacet:P42' );
 
 		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
@@ -50,19 +52,19 @@ class QueryStringParserTest extends TestCase {
 		$this->assertTrue( $constraints->hasNoValue() );
 	}
 
-	public function testParsesInstance(): void {
-		$parser = new QueryStringParser();
-		$query = $parser->parse( 'haswbstatement:P42=Q68' );
+	public function testParsesItemTypes(): void {
+		$parser = $this->newQueryStringParser();
+		$query = $parser->parse( 'haswbstatement:' . self::INSTANCE_TYPE_ID . '=Q68' );
 
-		$propertyId = new NumericPropertyId( 'P42' );
-		$itemId = new ItemId( 'Q68' );
+		$itemTypes = [
+			new ItemId( 'Q68' )
+		];
 
-		$this->assertEquals( $propertyId, $query->getInstancePropertyId() );
-		$this->assertEquals( $itemId, $query->getInstanceItemId() );
+		$this->assertEquals( $itemTypes, $query->getInstanceItemTypes() );
 	}
 
 	public function testParsesAndValues(): void {
-		$parser = new QueryStringParser();
+		$parser = $this->newQueryStringParser();
 		$query = $parser->parse( 'haswbfacet:P42=foo haswbfacet:P42=bar' );
 
 		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
@@ -74,7 +76,7 @@ class QueryStringParserTest extends TestCase {
 	}
 
 	public function testParsesOrValues(): void {
-		$parser = new QueryStringParser();
+		$parser = $this->newQueryStringParser();
 		$query = $parser->parse( 'haswbfacet:P42=foo|bar|baz' );
 
 		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
@@ -86,7 +88,7 @@ class QueryStringParserTest extends TestCase {
 	}
 
 	public function testParsesMinimum(): void {
-		$parser = new QueryStringParser();
+		$parser = $this->newQueryStringParser();
 		$query = $parser->parse( 'haswbfacet:P42>=42' );
 
 		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
@@ -95,7 +97,7 @@ class QueryStringParserTest extends TestCase {
 	}
 
 	public function testParsesMaximum(): void {
-		$parser = new QueryStringParser();
+		$parser = $this->newQueryStringParser();
 		$query = $parser->parse( 'haswbfacet:P42<=9001' );
 
 		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
@@ -104,7 +106,7 @@ class QueryStringParserTest extends TestCase {
 	}
 
 	public function testParsesRange(): void {
-		$parser = new QueryStringParser();
+		$parser = $this->newQueryStringParser();
 		$query = $parser->parse( 'haswbfacet:P42>=42 haswbfacet:P1=unrelated haswbfacet:P42<=9001' );
 
 		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
@@ -114,7 +116,7 @@ class QueryStringParserTest extends TestCase {
 	}
 
 	public function testHandlesMixedConstraintsAndFreeText(): void {
-		$parser = new QueryStringParser();
+		$parser = $this->newQueryStringParser();
 		$query = $parser->parse( 'kittens haswbfacet:P42=cute cats haswbfacet:P23>=9001' );
 
 		$this->assertSame( 'kittens cats', $query->getFreeText() );
@@ -129,7 +131,7 @@ class QueryStringParserTest extends TestCase {
 	public function testHandlesSingleQuotedString(): void {
 		$this->markTestSkipped( 'TODO' );
 
-		$parser = new QueryStringParser();
+		$parser = $this->newQueryStringParser();
 		$query = $parser->parse( 'haswbfacet:P42="foo bar" baz' );
 
 		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
@@ -144,7 +146,7 @@ class QueryStringParserTest extends TestCase {
 	public function testHandlesOrQuotedStrings(): void {
 		$this->markTestSkipped( 'TODO' );
 
-		$parser = new QueryStringParser();
+		$parser = $this->newQueryStringParser();
 		$query = $parser->parse( 'haswbfacet:P42="foo bar"|second|"third value" baz' );
 
 		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
@@ -154,6 +156,14 @@ class QueryStringParserTest extends TestCase {
 			$constraints->getOrSelectedValues()
 		);
 		$this->assertSame( 'baz', $query->getFreeText() );
+	}
+
+	private function newQueryStringParser(): QueryStringParser {
+		return new QueryStringParser(
+			instanceType: new Config(
+				instanceOfId: new NumericPropertyId( INSTANCE_TYPE_ID )
+			)->getInstanceOfId()
+		);
 	}
 
 }

--- a/tests/phpunit/Application/QueryStringParserTest.php
+++ b/tests/phpunit/Application/QueryStringParserTest.php
@@ -160,9 +160,9 @@ class QueryStringParserTest extends TestCase {
 
 	private function newQueryStringParser(): QueryStringParser {
 		return new QueryStringParser(
-			instanceType: new Config(
+			instanceType: ( new Config(
 				instanceOfId: new NumericPropertyId( INSTANCE_TYPE_ID )
-			)->getInstanceOfId()
+			) )->getInstanceOfId()
 		);
 	}
 

--- a/tests/phpunit/Application/QueryStringParserTest.php
+++ b/tests/phpunit/Application/QueryStringParserTest.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Application;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\QueryStringParser;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\NumericPropertyId;

--- a/tests/phpunit/Application/QueryTest.php
+++ b/tests/phpunit/Application/QueryTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraints;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraintsList;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\Query;
+use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\NumericPropertyId;
 
 /**

--- a/tests/phpunit/Application/QueryTest.php
+++ b/tests/phpunit/Application/QueryTest.php
@@ -68,4 +68,21 @@ class QueryTest extends TestCase {
 		);
 	}
 
+	public function testInstanceCanBeRetrieved(): void {
+		$p1Constraint = new PropertyConstraints( new NumericPropertyId( 'P1' ) );
+
+		$propertyId = new NumericPropertyId( 'P42' );
+		$itemId = new ItemId( 'Q68' );
+
+		$instance = [
+			'propertyId' => $propertyId,
+			'itemId' => $itemId
+		];
+
+		$query = new Query( new PropertyConstraintsList( $p1Constraint ), '', $instance );
+
+		$this->assertEquals( $propertyId, $query->getInstancePropertyId() );
+		$this->assertEquals( $itemId, $query->getInstanceItemId() );
+	}
+
 }

--- a/tests/phpunit/Application/QueryTest.php
+++ b/tests/phpunit/Application/QueryTest.php
@@ -69,21 +69,15 @@ class QueryTest extends TestCase {
 		);
 	}
 
-	public function testInstanceCanBeRetrieved(): void {
+	public function testItemTypeanBeRetrieved(): void {
 		$p1Constraint = new PropertyConstraints( new NumericPropertyId( 'P1' ) );
-
-		$propertyId = new NumericPropertyId( 'P42' );
-		$itemId = new ItemId( 'Q68' );
-
-		$instance = [
-			'propertyId' => $propertyId,
-			'itemId' => $itemId
+		$itemTypes = [
+			new ItemId( 'Q68' )
 		];
 
-		$query = new Query( new PropertyConstraintsList( $p1Constraint ), '', $instance );
+		$query = new Query( new PropertyConstraintsList( $p1Constraint ), '', $itemTypes );
 
-		$this->assertEquals( $propertyId, $query->getInstancePropertyId() );
-		$this->assertEquals( $itemId, $query->getInstanceItemId() );
+		$this->assertEquals( $itemTypes, $query->getInstanceItemTypes() );
 	}
 
 }


### PR DESCRIPTION
#40

Key changes:
- Parse instance from query string, and use it for the selected state for instance tab
- Add basic instance handling to `Query` and `QueryStringParser`
- Make facets view model based on current instance
- Change `getFilteredQueries()` to remove all WBFS query when `propertyId` is not provided
- Sync instance type example values with config in Docker image

To-dos:
- Add tests
- Create a new class for instance
- Get instances view model from config