### PR TITLE
Remove PHPStan requirement to specify iterable types

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,3 +17,6 @@ parameters:
 	excludePaths:
 		- src/EntryPoints/WikibaseFacetedSearchHooks.php
 		- src/Persistence/Search/Query/HasWbFacetFeature.php
+	reportUnmatchedIgnoredErrors: false
+	ignoreErrors:
+		- '#no value type specified in iterable type array\.$#'


### PR DESCRIPTION
As per https://github.com/ProfessionalWiki/WikibaseFacetedSearch/pull/122#discussion_r1917241908

Copied config from one of our recent projects, including `reportUnmatchedIgnoredErrors` to make dealing with the baseline file less annoying