### PR TITLE
Add aggregatable keyword field

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,8 @@ parameters:
 		- ../../includes/AutoLoader.php
 	excludePaths:
 		- src/EntryPoints/WikibaseFacetedSearchHooks.php
+		- src/Persistence/Search/AggregatableKeywordIndexField.php
+		- src/Persistence/Search/SearchIndexFieldsBuilder.php
 		- src/Persistence/Search/Query/HasWbFacetFeature.php
 	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:

--- a/src/Persistence/Search/AggregatableKeywordIndexField.php
+++ b/src/Persistence/Search/AggregatableKeywordIndexField.php
@@ -1,0 +1,13 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence\Search;
+
+use CirrusSearch\Search\CirrusIndexField;
+
+class AggregatableKeywordIndexField extends CirrusIndexField {
+
+	protected $typeName = 'keyword';
+
+}

--- a/src/Persistence/Search/SearchIndexFieldsBuilder.php
+++ b/src/Persistence/Search/SearchIndexFieldsBuilder.php
@@ -4,10 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence\Search;
 
+use CirrusSearch\CirrusSearch;
 use Exception;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\FacetConfig;
-use SearchEngine;
 use SearchIndexField;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookup;
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookup;
 class SearchIndexFieldsBuilder {
 
 	public function __construct(
-		private readonly SearchEngine $engine,
+		private readonly CirrusSearch $engine,
 		private readonly Config $config,
 		private readonly PropertyDataTypeLookup $dataTypeLookup
 	) {
@@ -35,7 +35,7 @@ class SearchIndexFieldsBuilder {
 			}
 
 			$name = $this->getFacetFieldName( $facetConfig );
-			$fields[$name] = $this->engine->makeSearchFieldMapping( $name, $fieldType );
+			$fields[$name] = $this->makeSearchFieldMapping( $name, $fieldType );
 		}
 
 		return $fields;
@@ -63,6 +63,14 @@ class SearchIndexFieldsBuilder {
 
 	private function getFacetFieldName( FacetConfig $facetConfig ): string {
 		return 'wbfs_' . $facetConfig->propertyId->getSerialization();
+	}
+
+	private function makeSearchFieldMapping( string $name, string $fieldType ): SearchIndexField {
+		if ( $fieldType === SearchIndexField::INDEX_TYPE_KEYWORD ) {
+			return new AggregatableKeywordIndexField( $name, $fieldType, $this->engine->getConfig() );
+		}
+
+		return $this->engine->makeSearchFieldMapping( $name, $fieldType );
 	}
 
 }

--- a/src/WikibaseFacetedSearchExtension.php
+++ b/src/WikibaseFacetedSearchExtension.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch;
 
+use CirrusSearch\CirrusSearch;
 use MediaWiki\MediaWikiServices;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ConfigLookup;
@@ -108,7 +109,7 @@ class WikibaseFacetedSearchExtension {
 		return new TemplateParser( __DIR__ . '/../templates' );
 	}
 
-	public function newSearchIndexFieldsBuilder( SearchEngine $engine ): SearchIndexFieldsBuilder {
+	public function newSearchIndexFieldsBuilder( CirrusSearch $engine ): SearchIndexFieldsBuilder {
 		return new SearchIndexFieldsBuilder(
 			engine:	$engine,
 			config: $this->getConfig(),

--- a/tests/phpunit/Persistence/Search/SearchIndexFieldsBuilderTest.php
+++ b/tests/phpunit/Persistence/Search/SearchIndexFieldsBuilderTest.php
@@ -6,7 +6,6 @@ namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence\Search;
 
 use CirrusSearch\CirrusSearch;
 use CirrusSearch\Search\DatetimeIndexField;
-use CirrusSearch\Search\KeywordIndexField;
 use CirrusSearch\Search\NumberIndexField;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
@@ -81,9 +80,9 @@ class SearchIndexFieldsBuilderTest extends TestCase {
 		$this->assertEquals(
 			[
 				'wbfs_P100' => new NumberIndexField( 'wbfs_P100', SearchIndexField::INDEX_TYPE_NUMBER, $this->cirrusSearch->getConfig() ),
-				'wbfs_P200' => new KeywordIndexField( 'wbfs_P200', SearchIndexField::INDEX_TYPE_KEYWORD, $this->cirrusSearch->getConfig() ),
+				'wbfs_P200' => new AggregatableKeywordIndexField( 'wbfs_P200', SearchIndexField::INDEX_TYPE_KEYWORD, $this->cirrusSearch->getConfig() ),
 				'wbfs_P300' => new DatetimeIndexField( 'wbfs_P300', SearchIndexField::INDEX_TYPE_DATETIME, $this->cirrusSearch->getConfig() ),
-				'wbfs_P400' => new KeywordIndexField( 'wbfs_P400', SearchIndexField::INDEX_TYPE_KEYWORD, $this->cirrusSearch->getConfig() )
+				'wbfs_P400' => new AggregatableKeywordIndexField( 'wbfs_P400', SearchIndexField::INDEX_TYPE_KEYWORD, $this->cirrusSearch->getConfig() )
 			],
 			$builder->createFields()
 		);
@@ -115,7 +114,7 @@ class SearchIndexFieldsBuilderTest extends TestCase {
 		$this->assertEquals(
 			[
 				'wbfs_P100' => new NumberIndexField( 'wbfs_P100', SearchIndexField::INDEX_TYPE_NUMBER, $this->cirrusSearch->getConfig() ),
-				'wbfs_P200' => new KeywordIndexField( 'wbfs_P200', SearchIndexField::INDEX_TYPE_KEYWORD, $this->cirrusSearch->getConfig() )
+				'wbfs_P200' => new AggregatableKeywordIndexField( 'wbfs_P200', SearchIndexField::INDEX_TYPE_KEYWORD, $this->cirrusSearch->getConfig() )
 			],
 			$builder->createFields()
 		);


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/WikibaseFacetedSearch/issues/23#issuecomment-2567096737

All WBFS string fields are now aggregatable:
![Screenshot_20250117_031359](https://github.com/user-attachments/assets/11470127-ba48-4ea5-8b11-8f56d2a3521d)

Query example:
```
GET /mediawiki_content_first/_search
{
  "size": 0,
  "aggs": {
    "unique_values": {
      "terms": {
        "field": "wbfs_P22", 
        "size": 10000
      }
    }
  }
}
```

Returns:
```
{
  "took" : 1,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 209,
      "relation" : "eq"
    },
    "max_score" : null,
    "hits" : [ ]
  },
  "aggregations" : {
    "unique_values" : {
      "doc_count_error_upper_bound" : 0,
      "sum_other_doc_count" : 0,
      "buckets" : [
        {
          "key" : "cs.LG",
          "doc_count" : 6
        },
        {
          "key" : "stat.ML",
          "doc_count" : 6
        },
        {
          "key" : "stat.ME",
          "doc_count" : 2
        },
        {
          "key" : "astro-ph.IM",
          "doc_count" : 1
        },
        {
          "key" : "cs.AI",
          "doc_count" : 1
        },
        {
          "key" : "math.ST",
          "doc_count" : 1
        },
        {
          "key" : "stat.TH",
          "doc_count" : 1
        }
      ]
    }
  }
}
```