### PR TITLE
Use localized label instead of entity IDs

### DIFF
--- a/src/EntryPoints/WikibaseFacetedSearchHooks.php
+++ b/src/EntryPoints/WikibaseFacetedSearchHooks.php
@@ -62,7 +62,7 @@ class WikibaseFacetedSearchHooks {
 		$output->addModules( 'ext.wikibase.facetedsearch' );
 
 		$output->addHTML(
-			WikibaseFacetedSearchExtension::getInstance()->getUiBuilder()->createHtml(
+			WikibaseFacetedSearchExtension::getInstance()->getUiBuilder( $specialSearch->getLanguage() )->createHtml(
 				searchQuery: $term
 			)
 		);

--- a/src/Presentation/UiBuilder.php
+++ b/src/Presentation/UiBuilder.php
@@ -112,7 +112,7 @@ class UiBuilder {
 	}
 
 	private function getLabelFromEntityId( EntityId $entityId ): string {
-		return $this->labelDescriptionLookup->getLabel( $entityId )->getText();
+		return $this->labelDescriptionLookup->getLabel( $entityId )?->getText() ?? $entityId->getSerialization();
 	}
 
 }

--- a/src/WikibaseFacetedSearchExtension.php
+++ b/src/WikibaseFacetedSearchExtension.php
@@ -184,10 +184,11 @@ class WikibaseFacetedSearchExtension {
 		return new ConfigJsonValidator( $schema );
 	}
 
-	public function getUiBuilder(): UiBuilder {
+	public function getUiBuilder( Language $language ): UiBuilder {
 		return new UiBuilder(
 			config: $this->getConfig(),
 			facetHtmlBuilder: $this->getFacetHtmlBuilder(),
+			labelDescriptionLookup: $this->newLabelDescriptionLookup( $language ),
 			templateParser: $this->getTemplateParser(),
 			queryStringParser: $this->getQueryStringParser()
 		);

--- a/tests/phpunit/Presentation/UiBuilderTest.php
+++ b/tests/phpunit/Presentation/UiBuilderTest.php
@@ -6,7 +6,6 @@ namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Presentation;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
-use ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraints;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraintsList;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\Query;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\QueryStringParser;
@@ -18,6 +17,7 @@ use ProfessionalWiki\WikibaseFacetedSearch\WikibaseFacetedSearchExtension;
 use RuntimeException;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\NumericPropertyId;
+use Wikibase\Lib\Store\FallbackLabelDescriptionLookup;
 
 /**
  * @covers \ProfessionalWiki\WikibaseFacetedSearch\Presentation\UiBuilder
@@ -39,27 +39,34 @@ class UiBuilderTest extends TestCase {
 
 	public function testTabsViewModelContainsItemTypeProperty(): void {
 		$config = new Config( instanceOfId: new NumericPropertyId( 'P1337' ) );
-		$templatePsy = new SpyTemplateParser();
+		$templateSpy = new SpyTemplateParser();
 
-		$this->newUiBuilder( config: $config, templatePsy: $templatePsy )
+		$this->newUiBuilder( config: $config, templateSpy: $templateSpy )
 			->createHtml( 'unimportant' );
 
 		$this->assertSame(
 			'P1337',
-			$templatePsy->getArgs()['instanceId']
+			$templateSpy->getArgs()['instanceId']
 		);
 	}
 
 	private function newUiBuilder(
 		?Config $config = null,
-		?SpyTemplateParser $templatePsy = null,
+		?SpyTemplateParser $templateSpy = null,
 		?QueryStringParser $queryStringParser = null
 	): UiBuilder {
 		return new UiBuilder(
 			$config ?? new Config(),
 			new SpyFacetHtmlBuilder(),
-			$templatePsy ?? new SpyTemplateParser(),
+			$this->newLabelDescriptionLookup(),
+			$templateSpy ?? new SpyTemplateParser(),
 			$queryStringParser ?? new StubQueryStringParser()
+		);
+	}
+
+	private function newLabelDescriptionLookup(): FallbackLabelDescriptionLookup {
+		return WikibaseFacetedSearchExtension::getInstance()->newLabelDescriptionLookup(
+			MediaWikiServices::getInstance()->getContentLanguage()
 		);
 	}
 
@@ -91,9 +98,9 @@ class UiBuilderTest extends TestCase {
 }
 JSON );
 
-		$templatePsy = new SpyTemplateParser();
+		$templateSpy = new SpyTemplateParser();
 
-		$this->newUiBuilder( config: $config, templatePsy: $templatePsy )
+		$this->newUiBuilder( config: $config, templateSpy: $templateSpy )
 			->createHtml( 'unimportant' );
 
 		$this->assertEquals(
@@ -114,7 +121,7 @@ JSON );
 					'selected' => false
 				],
 			],
-			$templatePsy->getArgs()['instances']
+			$templateSpy->getArgs()['instances']
 		);
 	}
 
@@ -139,11 +146,11 @@ JSON );
 }
 JSON );
 
-		$templatePsy = new SpyTemplateParser();
+		$templateSpy = new SpyTemplateParser();
 
 		$this->newUiBuilder(
 			config: $config,
-			templatePsy: $templatePsy,
+			templateSpy: $templateSpy,
 			queryStringParser: new StubQueryStringParser( new Query(
 				new PropertyConstraintsList(),
 				itemTypes: [ new ItemId( 'Q2' ) ]
@@ -173,7 +180,7 @@ JSON );
 					'selected' => false
 				],
 			],
-			$templatePsy->getArgs()['instances']
+			$templateSpy->getArgs()['instances']
 		);
 	}
 

--- a/tests/phpunit/Presentation/UiBuilderTest.php
+++ b/tests/phpunit/Presentation/UiBuilderTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Presentation;
 
+use MediaWiki\MediaWikiServices;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\Config;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraintsList;


### PR DESCRIPTION
#136

Key changes:
- Use labels when available for entity IDs on the facets
- Correct `templatePsy` spelling to `templateSpy`

Follow-up:
- Allow label from config to override the tab label (might be blocked by #107)