### PR TITLE
Turn facets into a modal in narrow viewport

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -91,7 +91,14 @@
 		},
 		"ext.wikibase.facetedsearch": {
 			"packageFiles": [
-				"ext.wikibase.facetedsearch.js"
+				"ext.wikibase.facetedsearch.js",
+				"dialog.js"
+			],
+			"styles": [
+				"dialog.less"
+			],
+			"dependencies": [
+				"mediawiki.page.ready"
 			]
 		},
 		"ext.wikibase.facetedsearch.docs.styles": {

--- a/resources/dialog.js
+++ b/resources/dialog.js
@@ -1,0 +1,76 @@
+class Dialog {
+	constructor( button, content, teleportTarget ) {
+		this.button = button;
+		this.content = content;
+		this.teleportTarget = teleportTarget;
+		this.originalTarget = content.parentNode;
+		this.opened = false;
+		this.onButtonClick = this.onButtonClick.bind( this );
+		this.onClickOutside = this.onClickOutside.bind( this );
+	}
+
+	init() {
+		const backdrop = document.createElement( 'div' );
+		backdrop.classList.add( 'wikibase-faceted-search__dialog-backdrop' );
+		this.backdrop = backdrop;
+
+		this.button.addEventListener( 'click', this.onButtonClick );
+	}
+
+	onButtonClick() {
+		if ( this.opened ) {
+			this.close();
+		} else {
+			this.open();
+		}
+	}
+
+	close() {
+		this.content.classList.remove( 'wikibase-faceted-search__dialog' );
+		this.originalTarget.appendChild( this.content );
+		this.backdrop.remove();
+		this.opened = false;
+		document.removeEventListener( 'click', this.onClickOutside );
+	}
+
+	open() {
+		this.content.classList.add( 'wikibase-faceted-search__dialog' );
+		this.backdrop.appendChild( this.content );
+		this.teleportTarget.appendChild( this.backdrop );
+		this.opened = true;
+		document.addEventListener( 'click', this.onClickOutside );
+	}
+
+	onClickOutside( event ) {
+		if (
+			!this.opened ||
+			this.content.contains( event.target ) ||
+			this.button.contains( event.target )
+		) {
+			return;
+		}
+		this.close();
+	}
+}
+
+/**
+ * Initializes a new Dialog instance with the provided button, content, and teleport target.
+ * Attaches event listeners to the button to toggle the dialog's open/close state.
+ *
+ * @param {HTMLButtonElement} button - The button element that triggers the dialog.
+ * @param {HTMLElement} content - The content element of the dialog.
+ * @param {HTMLDivElement} teleportTarget - The target element where the dialog's backdrop
+ * and content will be appended.
+ */
+function init( button, content, teleportTarget ) {
+	if ( !button || !content || !teleportTarget ) {
+		return;
+	}
+
+	new Dialog( button, content, teleportTarget ).init();
+}
+
+module.exports = {
+	init: init,
+	Dialog: Dialog // For unit tests
+};

--- a/resources/dialog.less
+++ b/resources/dialog.less
@@ -1,0 +1,21 @@
+@import 'mediawiki.skin.variables.less';
+
+.wikibase-faceted-search__dialog {
+	width: calc( 100% - @size-400 );
+	max-width: @size-3200;
+	max-height: calc( 100vh - @size-250 );
+	background-color: @background-color-base;
+	border: @border-base;
+	border-radius: @border-radius-base;
+	box-shadow: @box-shadow-drop-medium;
+	overflow: auto;
+
+	&-backdrop {
+		position: fixed;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background-color: @background-color-backdrop-light;
+	}
+}

--- a/resources/ext.wikibase.facetedsearch.js
+++ b/resources/ext.wikibase.facetedsearch.js
@@ -11,9 +11,18 @@ function init() {
 
 	const facets = document.querySelector( '.wikibase-faceted-search__facets' );
 	const instances = document.querySelector( '.wikibase-faceted-search__instances' );
+
 	if ( facets ) {
 		facets.addEventListener( 'input', onFacetsInput );
+
+		const
+			button = document.querySelector( '.wikibase-faceted-search__dialog-button' ),
+			content = document.querySelector( '.wikibase-faceted-search__facets' ),
+			teleportTarget = require( 'mediawiki.page.ready' ).teleportTarget;
+
+		require( './dialog.js' ).init( button, content, teleportTarget );
 	}
+
 	if ( instances ) {
 		instances.addEventListener( 'click', ( event ) => onInstancesClick( event, instances.dataset.instanceId ) );
 	}

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -10,19 +10,6 @@
 		overflow-x: auto;
 	}
 
-	&__sidebar {
-		.cdx-accordion {
-			&__content {
-				font-size: inherit;
-			}
-
-			.cdx-accordion__header {
-				font-size: inherit;
-				font-weight: @font-weight-bold;
-			}
-		}
-	}
-
 	&__icon {
 		// Needed the specificity to override cdx-mixin-css-icon mixin
 		&.wikibase-faceted-search__icon.wikibase-faceted-search__icon.wikibase-faceted-search__icon {
@@ -39,50 +26,46 @@
 		}
 	}
 
-	// Header that is also used as collapse button in mobile
-	&__header {
-		display: none;
-
-		@media ( max-width: @max-width-breakpoint-tablet ) {
-			display: block;
-		}
-
-		// Style as a ToggleButton
-		> summary {
-			display: flex;
-			align-items: center;
-			max-width: none;
-			user-select: none;
-		}
-
-		&[ open ] > summary {
-			border-bottom-left-radius: 0;
-			border-bottom-right-radius: 0;
-			background-color: @background-color-progressive;
-			border-color: transparent;
-			color: @color-inverted-fixed;
-		}
-	}
-
 	// Common
 	&__facets {
 		position: sticky;
 		top: @spacing-100;
 
-		// Default to collapsed state in tablet
 		@media ( max-width: @max-width-breakpoint-tablet ) {
 			display: none;
 
-			.wikibase-faceted-search__header[ open ] + & {
+			&.wikibase-faceted-search__dialog {
 				display: block;
-				border-style: solid;
-				border-width: 1px;
-				border-color: @border-color-base;
-				margin-bottom: -1px;
+			}
+		}
 
-				.wikibase-faceted-search__facet:last-child {
-					border-bottom: 0;
-				}
+		&-dialog-button.cdx-button {
+			width: 100%;
+			max-width: none;
+
+			@media ( min-width: @min-width-breakpoint-desktop ) {
+				display: none;
+			}
+		}
+
+		&-header {
+			position: sticky;
+			top: 0;
+			z-index: @z-index-sticky;
+			padding: @spacing-75;
+			border-bottom: @border-subtle;
+			font-weight: @font-weight-bold;
+			background-color: @background-color-base;
+		}
+
+		.cdx-accordion {
+			&__content {
+				font-size: inherit;
+			}
+
+			.cdx-accordion__header {
+				font-size: inherit;
+				font-weight: @font-weight-bold;
 			}
 		}
 	}

--- a/templates/Sidebar.mustache
+++ b/templates/Sidebar.mustache
@@ -1,12 +1,19 @@
-<details class="wikibase-faceted-search__header">
-	<summary class="cdx-button cdx-button--size-large cdx-button--fake-button cdx-button--fake-button--enabled">
+<button class="wikibase-faceted-search__facets-dialog-button wikibase-faceted-search__dialog-button cdx-button cdx-button--size-large">
+	<span
+		class="wikibase-faceted-search__icon wikibase-faceted-search__icon--filter cdx-button__icon"
+		aria-hidden="true"
+	></span>
+	{{msg-filters}}
+</button>
+<div class="wikibase-faceted-search__facets">
+	<div class="wikibase-faceted-search__facets-header mw-sticky-header-element">
 		<span
-			class="wikibase-faceted-search__icon wikibase-faceted-search__icon--filter cdx-button__icon"
+			class="wikibase-faceted-search__icon wikibase-faceted-search__icon--filter"
 			aria-hidden="true"
 		></span>
 		{{msg-filters}}
-	</summary>
-</details>
-<div class="wikibase-faceted-search__facets">
-	{{#facets}}{{>Facet}}{{/facets}}
+	</div>
+	<div class="wikibase-faceted-search__facets-list">
+		{{#facets}}{{>Facet}}{{/facets}}
+	</div>
 </div>

--- a/tests/jest/dialog.test.js
+++ b/tests/jest/dialog.test.js
@@ -1,0 +1,77 @@
+const actual = require( '../../resources/dialog.js' );
+
+beforeEach( () => {
+	const button = document.createElement( 'button' );
+	const content = document.createElement( 'div' );
+	const originalTarget = document.createElement( 'div' );
+	const teleportTarget = document.createElement( 'div' );
+
+	originalTarget.appendChild( content );
+
+	this.dialog = new actual.Dialog( button, content, teleportTarget );
+} );
+
+describe( 'close', () => {
+	beforeEach( () => {
+		this.dialog.init();
+		this.dialog.open();
+	} );
+
+	test( 'wikibase-faceted-search__dialog class is removed', () => {
+		this.dialog.close();
+		expect( this.dialog.content.classList.contains( 'wikibase-faceted-search__dialog' ) ).toBe( false );
+	} );
+
+	test( 'backdrop is removed from teleportTarget', () => {
+		this.dialog.close();
+		expect( this.dialog.backdrop.parentNode === this.dialog.teleportTarget ).toBe( false );
+	} );
+
+	test( 'content is removed from backdrop', () => {
+		this.dialog.close();
+		expect( this.dialog.content.parentNode === this.dialog.backdrop ).toBe( false );
+	} );
+
+	test( 'opened is set to false', () => {
+		this.dialog.close();
+		expect( this.dialog.opened ).toBe( false );
+	} );
+
+	test( 'document event listener is removed', () => {
+		const spy = jest.spyOn( document, 'removeEventListener' );
+		this.dialog.close();
+		expect( spy ).toHaveBeenCalledWith( 'click', this.dialog.onClickOutside );
+	} );
+} );
+
+describe( 'open', () => {
+	beforeEach( () => {
+		this.dialog.init();
+	} );
+
+	test( 'wikibase-faceted-search__dialog class is added', () => {
+		this.dialog.open();
+		expect( this.dialog.content.classList.contains( 'wikibase-faceted-search__dialog' ) ).toBe( true );
+	} );
+
+	test( 'backdrop is appened to teleportTarget', () => {
+		this.dialog.open();
+		expect( this.dialog.backdrop.parentNode === this.dialog.teleportTarget ).toBe( true );
+	} );
+
+	test( 'content is appended to backdrop', () => {
+		this.dialog.open();
+		expect( this.dialog.content.parentNode === this.dialog.backdrop ).toBe( true );
+	} );
+
+	test( 'opened is set to true', () => {
+		this.dialog.open();
+		expect( this.dialog.opened ).toBe( true );
+	} );
+
+	test( 'document event listener is added', () => {
+		const spy = jest.spyOn( document, 'addEventListener' );
+		this.dialog.open();
+		expect( spy ).toHaveBeenCalledWith( 'click', this.dialog.onClickOutside );
+	} );
+} );


### PR DESCRIPTION
Closes: #77

Key changes:
- Switch facets from collapsible element to a dialog in narrow viewport
- Add a generic `Dialog` class to handle dialogs
- Add filters header to facets

To-do:
- Show message under facet header when no facets are available


https://github.com/user-attachments/assets/19b4c12e-db01-4425-b93d-f2a348367626

