### PR TITLE
Use haswbfacet for parsing item type

### DIFF
--- a/src/Application/QueryStringParser.php
+++ b/src/Application/QueryStringParser.php
@@ -51,7 +51,7 @@ class QueryStringParser {
 	}
 
 	private function isInstanceOfPart( string $part ): bool {
-		return str_starts_with( $part, 'haswbfacet:' . $this->itemTypeProperty->getSerialization() );
+		return str_starts_with( $part, 'haswbfacet:' . $this->itemTypeProperty->getSerialization() . '=' );
 	}
 
 	private function isFacetPart( string $part ): bool {
@@ -64,8 +64,7 @@ class QueryStringParser {
 	 * @return ItemId[]
 	 */
 	private function extractItemTypes( string $part, array &$itemTypes ): array {
-		$part = substr( $part, strlen( 'haswbfacet:' . $this->itemTypeProperty->getSerialization() ) );
-		$itemTypeStr = explode( '=', $part, 2 )[1] ?? '';
+		$itemTypeStr = substr( $part, strlen( 'haswbfacet:' . $this->itemTypeProperty->getSerialization() . '=' ) );
 
 		if ( $itemTypeStr === '' ) {
 			return $itemTypes;

--- a/src/Application/QueryStringParser.php
+++ b/src/Application/QueryStringParser.php
@@ -22,10 +22,10 @@ class QueryStringParser {
 		$itemTypes = [];
 
 		foreach ( $this->splitQueryString( $queryString ) as $part ) {
-			if ( $this->isFacetPart( $part ) ) {
-				$constraints = $constraints->withConstraint( $this->handleFacetPart( $part, $constraints ) );
-			} elseif ( $this->isInstanceOfPart( $part ) ) {
+			if ( $this->isInstanceOfPart( $part ) ) {
 				$itemTypes = $this->extractItemTypes( $part, $itemTypes );
+			} elseif ( $this->isFacetPart( $part ) ) {
+				$constraints = $constraints->withConstraint( $this->handleFacetPart( $part, $constraints ) );
 			}
 			else {
 				$freeText[] = $part;
@@ -51,7 +51,7 @@ class QueryStringParser {
 	}
 
 	private function isInstanceOfPart( string $part ): bool {
-		return str_starts_with( $part, 'haswbstatement:' . $this->itemTypeProperty->getSerialization() );
+		return str_starts_with( $part, 'haswbfacet:' . $this->itemTypeProperty->getSerialization() );
 	}
 
 	private function isFacetPart( string $part ): bool {
@@ -64,7 +64,7 @@ class QueryStringParser {
 	 * @return ItemId[]
 	 */
 	private function extractItemTypes( string $part, array &$itemTypes ): array {
-		$part = substr( $part, strlen( 'haswbstatement:' ) );
+		$part = substr( $part, strlen( 'haswbfacet:' . $this->itemTypeProperty->getSerialization() ) );
 		$itemTypeStr = explode( '=', $part, 2 )[1] ?? '';
 
 		if ( $itemTypeStr === '' ) {

--- a/tests/phpunit/Application/QueryStringParserTest.php
+++ b/tests/phpunit/Application/QueryStringParserTest.php
@@ -59,7 +59,7 @@ class QueryStringParserTest extends TestCase {
 
 	public function testParsesSingleItemType(): void {
 		$parser = $this->newQueryStringParser( itemTypeProperty: 'P32' );
-		$query = $parser->parse( 'unrelated haswbstatement:P32=Q68 unrelated' );
+		$query = $parser->parse( 'unrelated haswbfacet:P32=Q68 unrelated' );
 
 		$itemTypes = [
 			new ItemId( 'Q68' )
@@ -70,7 +70,7 @@ class QueryStringParserTest extends TestCase {
 
 	public function testParsesMultipleItemTypes(): void {
 		$parser = $this->newQueryStringParser( itemTypeProperty: 'P32' );
-		$query = $parser->parse( 'unrelated haswbstatement:P32=Q68 haswbstatement:P32=Q67 unrelated haswbstatement:P32=Q69 unrelated' );
+		$query = $parser->parse( 'unrelated haswbfacet:P32=Q68 haswbfacet:P32=Q67 unrelated haswbfacet:P32=Q69 unrelated' );
 
 		$itemTypes = [
 			new ItemId( 'Q68' ),
@@ -81,9 +81,9 @@ class QueryStringParserTest extends TestCase {
 		$this->assertEquals( $itemTypes, $query->getItemTypes() );
 	}
 
-	public function testIgnoresHaswbstatementForNonItemTypePropertyProperties(): void {
+	public function testIgnoresHaswbfacetForNonItemTypePropertyProperties(): void {
 		$parser = $this->newQueryStringParser( itemTypeProperty: 'P32' );
-		$query = $parser->parse( 'haswbstatement:P1=wrongId haswbstatement:P32=Q68 haswbstatement:P2=alsoWrong' );
+		$query = $parser->parse( 'haswbfacet:P1=wrongId haswbfacet:P32=Q68 haswbfacet:P2=alsoWrong' );
 
 		$itemTypes = [
 			new ItemId( 'Q68' )
@@ -94,7 +94,7 @@ class QueryStringParserTest extends TestCase {
 
 	public function testIgnoresInvalidItemTypes(): void {
 		$parser = $this->newQueryStringParser( itemTypeProperty: 'P32' );
-		$query = $parser->parse( 'haswbstatement:P32=invalid haswbstatement:P32=Q68 haswbstatement:P32=wrong' );
+		$query = $parser->parse( 'haswbfacet:P32=invalid haswbfacet:P32=Q68 haswbfacet:P32=wrong' );
 
 		$itemTypes = [
 			new ItemId( 'Q68' )

--- a/tests/phpunit/Application/QueryStringParserTest.php
+++ b/tests/phpunit/Application/QueryStringParserTest.php
@@ -211,4 +211,32 @@ class QueryStringParserTest extends TestCase {
 		$this->assertEquals( [], $query->getItemTypes() );
 	}
 
+	public function testParsesSingleItemTypeWithOrValues(): void {
+		$parser = $this->newQueryStringParser( itemTypeProperty: 'P32' );
+		$query = $parser->parse( 'haswbfacet:P32=Q68 haswbfacet:P42=foo|bar|baz' );
+
+		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
+
+		$this->assertEquals( [ new ItemId( 'Q68' ) ], $query->getItemTypes() );
+
+		$this->assertEquals(
+			[ 'foo', 'bar', 'baz' ],
+			$constraints->getOrSelectedValues()
+		);
+	}
+
+	public function testParsesSingleItemTypeWithAndValues(): void {
+		$parser = $this->newQueryStringParser( itemTypeProperty: 'P32' );
+		$query = $parser->parse( 'haswbfacet:P32=Q68 haswbfacet:P42=foo haswbfacet:P42=bar' );
+
+		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
+
+		$this->assertEquals( [ new ItemId( 'Q68' ) ], $query->getItemTypes() );
+
+		$this->assertEquals(
+			[ 'foo', 'bar' ],
+			$constraints->getAndSelectedValues()
+		);
+	}
+
 }

--- a/tests/phpunit/Application/QueryStringParserTest.php
+++ b/tests/phpunit/Application/QueryStringParserTest.php
@@ -204,4 +204,11 @@ class QueryStringParserTest extends TestCase {
 		);
 	}
 
+	public function testParsesExactPropertyIdForItemType(): void {
+		$parser = $this->newQueryStringParser( itemTypeProperty: 'P32' );
+		$query = $parser->parse( 'unrelated haswbfacet:P320=Q68 unrelated' );
+
+		$this->assertEquals( [], $query->getItemTypes() );
+	}
+
 }


### PR DESCRIPTION
Fixes #150 

Required by https://github.com/ProfessionalWiki/WikibaseFacetedSearch/issues/53 to correctly detect the item type.