### PR TITLE
Fix incorrect label bottom margin in Chameleon

### DIFF
--- a/resources/ext.wikibase.facetedsearch.chameleon.less
+++ b/resources/ext.wikibase.facetedsearch.chameleon.less
@@ -1,4 +1,4 @@
-.wikibase-faceted-search__sidebar {
+.wikibase-faceted-search__facets {
 	// Chameleon add a margin-bottom: 0.5em to all <label> elements
 	// We need to reset that to let Codex handles the spacing
 	label {


### PR DESCRIPTION
The previous selector does not cover the modal