### PR TITLE
Handle empty OR values

### DIFF
--- a/src/Application/QueryStringParser.php
+++ b/src/Application/QueryStringParser.php
@@ -97,7 +97,7 @@ class QueryStringParser {
 
 		if ( $operator === '=' ) {
 			if ( str_contains( $value, '|' ) ) {
-				return $propertyConstraints->withOrValues( ...explode( '|', $value ) );
+				return $propertyConstraints->withOrValues( ...$this->getNonEmptyOrValues( $value ) );
 			}
 
 			return $propertyConstraints->withAdditionalAndValue( $value );
@@ -159,4 +159,13 @@ class QueryStringParser {
 		return '';
 	}
 
+	/**
+	 * @return string[]
+	 */
+	private function getNonEmptyOrValues( string $value ): array {
+		return array_filter(
+			explode( '|', $value ),
+			fn( string $orValue ): bool => $orValue !== ''
+		);
+	}
 }

--- a/tests/phpunit/Application/QueryStringParserTest.php
+++ b/tests/phpunit/Application/QueryStringParserTest.php
@@ -127,6 +127,42 @@ class QueryStringParserTest extends TestCase {
 		);
 	}
 
+	public function testParsesSingleOrValueWithLeadingPipe(): void {
+		$parser = $this->newQueryStringParser();
+		$query = $parser->parse( 'haswbfacet:P42=|foo' );
+
+		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
+
+		$this->assertEquals(
+			[ 'foo' ],
+			$constraints->getOrSelectedValues()
+		);
+	}
+
+	public function testParsesSingleOrValueWithTrailingPipe(): void {
+		$parser = $this->newQueryStringParser();
+		$query = $parser->parse( 'haswbfacet:P42=foo|' );
+
+		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
+
+		$this->assertEquals(
+			[ 'foo' ],
+			$constraints->getOrSelectedValues()
+		);
+	}
+
+	public function testRemovesEmptyOrValues(): void {
+		$parser = $this->newQueryStringParser();
+		$query = $parser->parse( 'haswbfacet:P42=|foo||bar||baz|' );
+
+		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
+
+		$this->assertEquals(
+			[ 'foo', 'bar', 'baz' ],
+			$constraints->getOrSelectedValues()
+		);
+	}
+
 	public function testParsesMinimum(): void {
 		$parser = $this->newQueryStringParser();
 		$query = $parser->parse( 'haswbfacet:P42>=42' );


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/WikibaseFacetedSearch/issues/166

* In general: removes empty values: `haswbfacet:p42=foo||bar`
* Specific: allows a single OR value to be correctly parsed as an OR value: `haswbfacet:P42=Q100|`