### PR TITLE
Refactor list facet query generation logic

### DIFF
--- a/resources/ext.wikibase.facetedsearch.js
+++ b/resources/ext.wikibase.facetedsearch.js
@@ -84,8 +84,12 @@ function onInstancesClick( event, instanceId ) {
  * @param {?string} mode
  */
 function onListFacetInput( facet, propertyId, mode ) {
+	const selectedValues = getListFacetSelectedValues( facet );
+	if ( selectedValues.length === 0 ) {
+		return;
+	}
 	mode = mode || getListFacetQueryMode( facet );
-	const newQueries = getListFacetQuerySegments( facet, propertyId, mode );
+	const newQueries = getListFacetQuerySegments( selectedValues, propertyId, mode );
 	submitSearchForm( buildQueryString( specialSearchInput.value, newQueries, propertyId ) );
 }
 
@@ -153,35 +157,41 @@ function updateErrorState( input ) {
 }
 
 /**
- * Extracts the queries from a list facet element.
+ * Extracts the selected facet items from a list facet element.
  *
  * @param {HTMLDivElement} facet
- * @param {string} propertyId
- * @param {string} mode
  * @return {string[]}
  */
-function getListFacetQuerySegments( facet, propertyId, mode ) {
-	const checkedValues = [];
+function getListFacetSelectedValues( facet ) {
+	const selectedValues = [];
 
 	[ ...facet.querySelectorAll( '.wikibase-faceted-search__facet-item' ) ].forEach( ( facetItem ) => {
 		const checkbox = facetItem.querySelector( '.cdx-checkbox__input' );
 		if ( !checkbox || !checkbox.checked || !checkbox.value ) {
 			return;
 		}
-		checkedValues.push( checkbox.value );
+		selectedValues.push( checkbox.value );
 	} );
 
-	if ( checkedValues.length === 0 ) {
-		return [];
-	}
+	return selectedValues;
+}
 
+/**
+ * Constructs an array of list facet queries based on the provided selected values.
+ *
+ * @param {string[]} selectedValues
+ * @param {string} propertyId
+ * @param {string} mode
+ * @return {string[]}
+ */
+function getListFacetQuerySegments( selectedValues, propertyId, mode ) {
 	const segments = [];
 	if ( mode === 'AND' ) {
-		checkedValues.forEach( ( value ) => {
+		selectedValues.forEach( ( value ) => {
 			segments.push( `haswbfacet:${ propertyId }=${ value }` );
 		} );
 	} else {
-		segments.push( `haswbfacet:${ propertyId }=${ checkedValues.join( '|' ) }` );
+		segments.push( `haswbfacet:${ propertyId }=${ selectedValues.join( '|' ) }` );
 	}
 
 	return segments;

--- a/resources/ext.wikibase.facetedsearch.js
+++ b/resources/ext.wikibase.facetedsearch.js
@@ -264,6 +264,7 @@ init();
 // Export for unit tests
 module.exports = {
 	getListFacetQueryMode,
+	getListFacetSelectedValues,
 	getListFacetQuerySegments,
 	getRangeFacetQuerySegments,
 	buildQueryString

--- a/tests/jest/ext.wikibase.facetedsearch.test.js
+++ b/tests/jest/ext.wikibase.facetedsearch.test.js
@@ -38,37 +38,43 @@ describe( 'getListFacetQueryMode', () => {
 	} );
 } );
 
-describe( 'getListFacetQuerySegments', () => {
-	test( 'Query segements for list facet with no checked items', () => {
+describe( 'getListFacetSelectedValues', () => {
+	test( 'List facet with no checked items', () => {
 		document.body.innerHTML = `
 			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q1"></div>
 			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q2"></div>
 			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q3"></div>
 		`;
 
-		expect( actual.getListFacetQuerySegments( document.body, 'P1' ) )
+		expect( actual.getListFacetSelectedValues( document.body ) )
 			.toEqual( [] );
 	} );
 
-	test( 'Query segements for list facet with multiple checked items in AND mode', () => {
+	test( 'List facet with multiple checked items', () => {
 		document.body.innerHTML = `
 			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q1"></div>
 			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q2" checked></div>
 			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q3" checked></div>
 		`;
 
-		expect( actual.getListFacetQuerySegments( document.body, 'P1', 'AND' ) )
+		expect( actual.getListFacetSelectedValues( document.body ) )
+			.toEqual( [ 'Q2', 'Q3' ] );
+	} );
+} );
+
+describe( 'getListFacetQuerySegments', () => {
+	test( 'Query segements for list facet with no selected values', () => {
+		expect( actual.getListFacetQuerySegments( [], 'P1' ) )
+			.toEqual( [ 'haswbfacet:P1=' ] );
+	} );
+
+	test( 'Query segements for list facet with multiple selected values in AND mode', () => {
+		expect( actual.getListFacetQuerySegments( [ 'Q2', 'Q3' ], 'P1', 'AND' ) )
 			.toEqual( [ 'haswbfacet:P1=Q2', 'haswbfacet:P1=Q3' ] );
 	} );
 
-	test( 'Query segements for list facet with multiple checked items in OR mode', () => {
-		document.body.innerHTML = `
-			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q1"></div>
-			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q2" checked></div>
-			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q3" checked></div>
-		`;
-
-		expect( actual.getListFacetQuerySegments( document.body, 'P1', 'OR' ) )
+	test( 'Query segements for list facet with multiple selected values in OR mode', () => {
+		expect( actual.getListFacetQuerySegments( [ 'Q2', 'Q3' ], 'P1', 'OR' ) )
 			.toEqual( [ 'haswbfacet:P1=Q2|Q3' ] );
 	} );
 } );


### PR DESCRIPTION
Key changes:
- Move finding selected values from DOM from `getListFacetQuerySegments` to `getListFacetSelectedValues`
- Rename `checkedValues` to `selectedValues`
- Only pass `selectedValues` to `getListFacetQuerySegments` instead of the `facet` element