### PR TITLE
Follow up to #169

### DIFF
--- a/resources/ext.wikibase.facetedsearch.js
+++ b/resources/ext.wikibase.facetedsearch.js
@@ -85,9 +85,6 @@ function onInstancesClick( event, instanceId ) {
  */
 function onListFacetInput( facet, propertyId, mode ) {
 	const selectedValues = getListFacetSelectedValues( facet );
-	if ( selectedValues.length === 0 ) {
-		return;
-	}
 	mode = mode || getListFacetQueryMode( facet );
 	const newQueries = getListFacetQuerySegments( selectedValues, propertyId, mode );
 	submitSearchForm( buildQueryString( specialSearchInput.value, newQueries, propertyId ) );

--- a/resources/ext.wikibase.facetedsearch.js
+++ b/resources/ext.wikibase.facetedsearch.js
@@ -84,7 +84,7 @@ function onInstancesClick( event, instanceId ) {
  * @param {?string} mode
  */
 function onListFacetInput( facet, propertyId, mode ) {
-	const selectedValues = getListFacetSelectedValues( facet );
+	const selectedValues = getListFacetSelectedItems( facet );
 	mode = mode || getListFacetQueryMode( facet );
 	const newQueries = getListFacetQuerySegments( selectedValues, propertyId, mode );
 	submitSearchForm( buildQueryString( specialSearchInput.value, newQueries, propertyId ) );
@@ -159,7 +159,7 @@ function updateErrorState( input ) {
  * @param {HTMLDivElement} facet
  * @return {string[]}
  */
-function getListFacetSelectedValues( facet ) {
+function getListFacetSelectedItems( facet ) {
 	const selectedValues = [];
 
 	[ ...facet.querySelectorAll( '.wikibase-faceted-search__facet-item' ) ].forEach( ( facetItem ) => {
@@ -261,7 +261,7 @@ init();
 // Export for unit tests
 module.exports = {
 	getListFacetQueryMode,
-	getListFacetSelectedValues,
+	getListFacetSelectedItems,
 	getListFacetQuerySegments,
 	getRangeFacetQuerySegments,
 	buildQueryString

--- a/resources/ext.wikibase.facetedsearch.js
+++ b/resources/ext.wikibase.facetedsearch.js
@@ -84,7 +84,7 @@ function onInstancesClick( event, instanceId ) {
  * @param {?string} mode
  */
 function onListFacetInput( facet, propertyId, mode ) {
-	const selectedValues = getListFacetSelectedItems( facet );
+	const selectedValues = getListFacetSelectedValues( facet );
 	mode = mode || getListFacetQueryMode( facet );
 	const newQueries = getListFacetQuerySegments( selectedValues, propertyId, mode );
 	submitSearchForm( buildQueryString( specialSearchInput.value, newQueries, propertyId ) );
@@ -154,12 +154,12 @@ function updateErrorState( input ) {
 }
 
 /**
- * Extracts the selected facet items from a list facet element.
+ * Extracts the selected facet values from a list facet element.
  *
  * @param {HTMLDivElement} facet
  * @return {string[]}
  */
-function getListFacetSelectedItems( facet ) {
+function getListFacetSelectedValues( facet ) {
 	const selectedValues = [];
 
 	[ ...facet.querySelectorAll( '.wikibase-faceted-search__facet-item' ) ].forEach( ( facetItem ) => {
@@ -261,7 +261,7 @@ init();
 // Export for unit tests
 module.exports = {
 	getListFacetQueryMode,
-	getListFacetSelectedItems,
+	getListFacetSelectedValues,
 	getListFacetQuerySegments,
 	getRangeFacetQuerySegments,
 	buildQueryString

--- a/tests/jest/ext.wikibase.facetedsearch.test.js
+++ b/tests/jest/ext.wikibase.facetedsearch.test.js
@@ -38,7 +38,7 @@ describe( 'getListFacetQueryMode', () => {
 	} );
 } );
 
-describe( 'getListFacetSelectedItems', () => {
+describe( 'getListFacetSelectedValues', () => {
 	test( 'List facet with no checked items', () => {
 		document.body.innerHTML = `
 			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q1"></div>
@@ -46,7 +46,7 @@ describe( 'getListFacetSelectedItems', () => {
 			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q3"></div>
 		`;
 
-		expect( actual.getListFacetSelectedItems( document.body ) )
+		expect( actual.getListFacetSelectedValues( document.body ) )
 			.toEqual( [] );
 	} );
 
@@ -57,7 +57,7 @@ describe( 'getListFacetSelectedItems', () => {
 			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q3" checked></div>
 		`;
 
-		expect( actual.getListFacetSelectedItems( document.body ) )
+		expect( actual.getListFacetSelectedValues( document.body ) )
 			.toEqual( [ 'Q2', 'Q3' ] );
 	} );
 } );

--- a/tests/jest/ext.wikibase.facetedsearch.test.js
+++ b/tests/jest/ext.wikibase.facetedsearch.test.js
@@ -38,7 +38,7 @@ describe( 'getListFacetQueryMode', () => {
 	} );
 } );
 
-describe( 'getListFacetSelectedValues', () => {
+describe( 'getListFacetSelectedItems', () => {
 	test( 'List facet with no checked items', () => {
 		document.body.innerHTML = `
 			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q1"></div>
@@ -46,7 +46,7 @@ describe( 'getListFacetSelectedValues', () => {
 			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q3"></div>
 		`;
 
-		expect( actual.getListFacetSelectedValues( document.body ) )
+		expect( actual.getListFacetSelectedItems( document.body ) )
 			.toEqual( [] );
 	} );
 
@@ -57,7 +57,7 @@ describe( 'getListFacetSelectedValues', () => {
 			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q3" checked></div>
 		`;
 
-		expect( actual.getListFacetSelectedValues( document.body ) )
+		expect( actual.getListFacetSelectedItems( document.body ) )
 			.toEqual( [ 'Q2', 'Q3' ] );
 	} );
 } );


### PR DESCRIPTION
Key changes:
- Remove early return for empty list facet input (fixes: #172)
- Rename `selectedItems` to `selectedValues` (https://github.com/ProfessionalWiki/WikibaseFacetedSearch/pull/169#discussion_r1939208928)