### PR TITLE
Use specific HTML class names for better semantics

### DIFF
--- a/resources/ext.wikibase.facetedsearch.js
+++ b/resources/ext.wikibase.facetedsearch.js
@@ -51,11 +51,11 @@ function onFacetsInput( event ) {
 	}
 
 	// TODO: Clean up the facet type detection logic after MVP or when we have more facet types
-	if ( target.classList.contains( 'cdx-checkbox__input' ) ) {
+	if ( target.classList.contains( 'wikibase-faceted-search__facet-item-checkbox' ) ) {
 		onListFacetInput( facet, propertyId );
-	} else if ( target.classList.contains( 'cdx-button' ) ) {
+	} else if ( target.classList.contains( 'wikibase-faceted-search__facet-toggle-button' ) ) {
 		onListFacetInput( facet, propertyId, target.value );
-	} else if ( target.classList.contains( 'cdx-text-input__input' ) ) {
+	} else if ( target.classList.contains( 'wikibase-faceted-search__facet-item-input' ) ) {
 		onRangeFacetInput( facet, propertyId );
 	}
 }
@@ -109,8 +109,8 @@ function getListFacetQueryMode( facet ) {
  */
 function onRangeFacetInput( facet, propertyId ) {
 	const applyButton = facet.querySelector( '.wikibase-faceted-search__facet-item-range-apply' );
-	const minInput = facet.querySelector( '.wikibase-faceted-search__facet-item-range-min > .cdx-text-input__input' );
-	const maxInput = facet.querySelector( '.wikibase-faceted-search__facet-item-range-max > .cdx-text-input__input' );
+	const minInput = facet.querySelector( '.wikibase-faceted-search__facet-item-range-min > .wikibase-faceted-search__facet-item-input' );
+	const maxInput = facet.querySelector( '.wikibase-faceted-search__facet-item-range-max > .wikibase-faceted-search__facet-item-input' );
 
 	if ( !applyButton || !minInput || !maxInput ) {
 		return;
@@ -163,7 +163,7 @@ function getListFacetSelectedValues( facet ) {
 	const selectedValues = [];
 
 	[ ...facet.querySelectorAll( '.wikibase-faceted-search__facet-item' ) ].forEach( ( facetItem ) => {
-		const checkbox = facetItem.querySelector( '.cdx-checkbox__input' );
+		const checkbox = facetItem.querySelector( '.wikibase-faceted-search__facet-item-checkbox' );
 		if ( !checkbox || !checkbox.checked || !checkbox.value ) {
 			return;
 		}

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -77,9 +77,18 @@
 		border-radius: @border-radius-base;
 		overflow: hidden;
 
-		.cdx-button {
-			border-radius: 0;
+		&-button {
 			width: 100%;
+
+			&:not( :first-child ) {
+				border-top-left-radius: 0;
+				border-bottom-left-radius: 0;
+			}
+
+			&:not( :last-child ) {
+				border-top-right-radius: 0;
+				border-bottom-right-radius: 0;
+			}
 		}
 	}
 

--- a/templates/FacetItemCheckbox.mustache
+++ b/templates/FacetItemCheckbox.mustache
@@ -4,7 +4,7 @@
 	<div class="cdx-checkbox__wrapper">
 		<input
 			id="{{id}}"
-			class="cdx-checkbox__input"
+			class="wikibase-faceted-search__facet-item-checkbox cdx-checkbox__input"
 			type="checkbox"
 			value="{{value}}"
 			{{#checked}}checked{{/checked}}

--- a/templates/ListFacet.mustache
+++ b/templates/ListFacet.mustache
@@ -2,7 +2,7 @@
 	<div class="wikibase-faceted-search__facet-toggle">
 		{{#and}}
 			<button 
-			class="cdx-button {{#selected}}cdx-button--action-progressive cdx-button--weight-primary{{/selected}}"
+			class="wikibase-faceted-search__facet-toggle-button cdx-button {{#selected}}cdx-button--action-progressive cdx-button--weight-primary{{/selected}}"
 			value="{{value}}"
 			{{#disabled}}disabled{{/disabled}}
 			>
@@ -11,7 +11,7 @@
 		{{/and}}
 		{{#or}}
 			<button
-			class="cdx-button {{#selected}}cdx-button--action-progressive cdx-button--weight-primary{{/selected}}"
+			class="wikibase-faceted-search__facet-toggle-button cdx-button {{#selected}}cdx-button--action-progressive cdx-button--weight-primary{{/selected}}"
 			value="{{value}}"
 			{{#disabled}}disabled{{/disabled}}
 			>

--- a/templates/RangeFacet.mustache
+++ b/templates/RangeFacet.mustache
@@ -5,7 +5,7 @@
 	}}
 	<div class="wikibase-faceted-search__facet-item-range-min cdx-text-input">
 		<input
-			class="cdx-text-input__input"
+			class="wikibase-faceted-search__facet-item-input cdx-text-input__input"
 			type="number"
 			placeholder="{{msg-min}}"
 			value="{{current-min}}"
@@ -13,7 +13,7 @@
 	</div>
 	<div class="wikibase-faceted-search__facet-item-range-max cdx-text-input">
 		<input
-			class="cdx-text-input__input"
+			class="wikibase-faceted-search__facet-item-input cdx-text-input__input"
 			type="number"
 			placeholder="{{msg-max}}"
 			value="{{current-max}}"

--- a/tests/jest/ext.wikibase.facetedsearch.test.js
+++ b/tests/jest/ext.wikibase.facetedsearch.test.js
@@ -41,9 +41,9 @@ describe( 'getListFacetQueryMode', () => {
 describe( 'getListFacetSelectedValues', () => {
 	test( 'List facet with no checked items', () => {
 		document.body.innerHTML = `
-			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q1"></div>
-			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q2"></div>
-			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q3"></div>
+			<div class="wikibase-faceted-search__facet-item"><input class="wikibase-faceted-search__facet-item-checkbox" type="checkbox" value="Q1"></div>
+			<div class="wikibase-faceted-search__facet-item"><input class="wikibase-faceted-search__facet-item-checkbox" type="checkbox" value="Q2"></div>
+			<div class="wikibase-faceted-search__facet-item"><input class="wikibase-faceted-search__facet-item-checkbox" type="checkbox" value="Q3"></div>
 		`;
 
 		expect( actual.getListFacetSelectedValues( document.body ) )
@@ -52,9 +52,9 @@ describe( 'getListFacetSelectedValues', () => {
 
 	test( 'List facet with multiple checked items', () => {
 		document.body.innerHTML = `
-			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q1"></div>
-			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q2" checked></div>
-			<div class="wikibase-faceted-search__facet-item"><input class="cdx-checkbox__input" type="checkbox" value="Q3" checked></div>
+			<div class="wikibase-faceted-search__facet-item"><input class="wikibase-faceted-search__facet-item-checkbox" type="checkbox" value="Q1"></div>
+			<div class="wikibase-faceted-search__facet-item"><input class="wikibase-faceted-search__facet-item-checkbox" type="checkbox" value="Q2" checked></div>
+			<div class="wikibase-faceted-search__facet-item"><input class="wikibase-faceted-search__facet-item-checkbox" type="checkbox" value="Q3" checked></div>
 		`;
 
 		expect( actual.getListFacetSelectedValues( document.body ) )


### PR DESCRIPTION
Key changes
- Use extension-specific class names instead of relying on Codex class names for elements that are used in JS (fixes https://github.com/ProfessionalWiki/WikibaseFacetedSearch/pull/164#issuecomment-2644733861)
- Clean up toggle button styles