### PR TITLE
Handle empty selected values

### DIFF
--- a/resources/ext.wikibase.facetedsearch.js
+++ b/resources/ext.wikibase.facetedsearch.js
@@ -184,11 +184,15 @@ function getListFacetSelectedValues( facet ) {
 function getListFacetQuerySegments( selectedValues, propertyId, mode ) {
 	const segments = [];
 	if ( mode === 'AND' ) {
+		if ( selectedValues.length === 0 ) {
+			segments.push( `haswbfacet:${ propertyId }=` );
+		}
 		selectedValues.forEach( ( value ) => {
 			segments.push( `haswbfacet:${ propertyId }=${ value }` );
 		} );
 	} else {
-		segments.push( `haswbfacet:${ propertyId }=${ selectedValues.join( '|' ) }` );
+		const suffix = selectedValues.length <= 1 ? '|' : '';
+		segments.push( `haswbfacet:${ propertyId }=${ selectedValues.join( '|' ) }${ suffix }` );
 	}
 
 	return segments;

--- a/src/Application/QueryStringParser.php
+++ b/src/Application/QueryStringParser.php
@@ -97,7 +97,7 @@ class QueryStringParser {
 
 		if ( $operator === '=' ) {
 			if ( str_contains( $value, '|' ) ) {
-				return $propertyConstraints->withOrValues( ...$this->getNonEmptyOrValues( $value ) );
+				return $propertyConstraints->withOrValues( ...explode( '|', $value ) );
 			}
 
 			return $propertyConstraints->withAdditionalAndValue( $value );
@@ -159,13 +159,4 @@ class QueryStringParser {
 		return '';
 	}
 
-	/**
-	 * @return string[]
-	 */
-	private function getNonEmptyOrValues( string $value ): array {
-		return array_filter(
-			explode( '|', $value ),
-			fn( string $orValue ): bool => $orValue !== ''
-		);
-	}
 }

--- a/src/Presentation/ListFacetHtmlBuilder.php
+++ b/src/Presentation/ListFacetHtmlBuilder.php
@@ -104,7 +104,10 @@ class ListFacetHtmlBuilder implements FacetHtmlBuilder {
 		$maxVisibleCheckboxes = 5; // TODO: Make this configurable
 		$combineWithAnd = $this->shouldCombineWithAnd( $config, $state );
 
-		$selectedValues = $combineWithAnd ? $state->getAndSelectedValues() : $state->getOrSelectedValues();
+		$selectedValues = array_filter(
+			$combineWithAnd ? $state->getAndSelectedValues() : $state->getOrSelectedValues(),
+			fn( $value ) => $value !== ''
+		);
 
 		$checkboxes = [];
 

--- a/tests/jest/ext.wikibase.facetedsearch.test.js
+++ b/tests/jest/ext.wikibase.facetedsearch.test.js
@@ -63,12 +63,12 @@ describe( 'getListFacetSelectedValues', () => {
 } );
 
 describe( 'getListFacetQuerySegments', () => {
-	test( 'Query segements for list facet with no selected values', () => {
+	test( 'Query segments for list facet with no selected values and no type', () => {
 		expect( actual.getListFacetQuerySegments( [], 'P1' ) )
-			.toEqual( [ 'haswbfacet:P1=' ] );
+			.toEqual( [ 'haswbfacet:P1=|' ] );
 	} );
 
-	test( 'Query segements for list facet with single selected value in AND mode', () => {
+	test( 'Query segments for list facet with single selected value in AND mode', () => {
 		expect( actual.getListFacetQuerySegments( [ 'Q2' ], 'P1', 'AND' ) )
 			.toEqual( [ 'haswbfacet:P1=Q2' ] );
 	} );
@@ -80,12 +80,22 @@ describe( 'getListFacetQuerySegments', () => {
 
 	test( 'Query segements for list facet with single selected value in OR mode', () => {
 		expect( actual.getListFacetQuerySegments( [ 'Q2' ], 'P1', 'OR' ) )
-			.toEqual( [ 'haswbfacet:P1=Q2' ] );
+			.toEqual( [ 'haswbfacet:P1=Q2|' ] );
 	} );
 
 	test( 'Query segements for list facet with multiple selected values in OR mode', () => {
 		expect( actual.getListFacetQuerySegments( [ 'Q2', 'Q3' ], 'P1', 'OR' ) )
 			.toEqual( [ 'haswbfacet:P1=Q2|Q3' ] );
+	} );
+
+	test( 'Query segments for list facet with no selected AND values', () => {
+		expect( actual.getListFacetQuerySegments( [], 'P1', 'AND' ) )
+			.toEqual( [ 'haswbfacet:P1=' ] );
+	} );
+
+	test( 'Query segments for list facet with no selected OR values', () => {
+		expect( actual.getListFacetQuerySegments( [], 'P1', 'OR' ) )
+			.toEqual( [ 'haswbfacet:P1=|' ] );
 	} );
 } );
 

--- a/tests/phpunit/Application/QueryStringParserTest.php
+++ b/tests/phpunit/Application/QueryStringParserTest.php
@@ -134,7 +134,7 @@ class QueryStringParserTest extends TestCase {
 		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
 
 		$this->assertEquals(
-			[ 'foo' ],
+			[ '', 'foo' ],
 			$constraints->getOrSelectedValues()
 		);
 	}
@@ -146,19 +146,19 @@ class QueryStringParserTest extends TestCase {
 		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
 
 		$this->assertEquals(
-			[ 'foo' ],
+			[ 'foo', '' ],
 			$constraints->getOrSelectedValues()
 		);
 	}
 
-	public function testRemovesEmptyOrValues(): void {
+	public function testKeepsSingleEmptyOrValue(): void {
 		$parser = $this->newQueryStringParser();
 		$query = $parser->parse( 'haswbfacet:P42=|foo||bar||baz|' );
 
 		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
 
 		$this->assertEquals(
-			[ 'foo', 'bar', 'baz' ],
+			[ '', 'foo', 'bar', 'baz' ],
 			$constraints->getOrSelectedValues()
 		);
 	}
@@ -272,6 +272,30 @@ class QueryStringParserTest extends TestCase {
 		$this->assertEquals(
 			[ 'foo', 'bar' ],
 			$constraints->getAndSelectedValues()
+		);
+	}
+
+	public function testHasSingleEmptyValueIfAndValueIsEmpty(): void {
+		$parser = $this->newQueryStringParser();
+		$query = $parser->parse( 'haswbfacet:P42=' );
+
+		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
+
+		$this->assertEquals(
+			[ '' ],
+			$constraints->getAndSelectedValues()
+		);
+	}
+
+	public function testHasSingleEmptyValueIfAllOrValuesAreEmpty(): void {
+		$parser = $this->newQueryStringParser();
+		$query = $parser->parse( 'haswbfacet:P42=|' );
+
+		$constraints = $query->getConstraintsForProperty( new NumericPropertyId( 'P42' ) );
+
+		$this->assertEquals(
+			[ '' ],
+			$constraints->getOrSelectedValues()
 		);
 	}
 

--- a/tests/phpunit/Persistence/Search/Query/ListFacetQueryBuilderTest.php
+++ b/tests/phpunit/Persistence/Search/Query/ListFacetQueryBuilderTest.php
@@ -169,4 +169,15 @@ class ListFacetQueryBuilderTest extends TestCase {
 		);
 	}
 
+	public function testBuildsNullQueryWhenListIsEmpty(): void {
+		$query = $this->newFacetQueryBuilder()->buildQuery(
+			$this->newListFacetConfig( self::STRING_PROPERTY ),
+			new PropertyConstraints(
+				new NumericPropertyId( self::STRING_PROPERTY )
+			)
+		);
+
+		$this->assertNull( $query );
+	}
+
 }


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/WikibaseFacetedSearch/issues/166

Query keywords:
* `haswbfacet:P42=` means `AND` without affecting search
* `haswbfacet:P42=|` measn `OR` without affecting search
* `haswbfacet:P42=9000` means `AND` (same as before)
* `haswbfacet:P42=9000|` means `OR` (impact on query is same as `AND`)
* `haswbfacet:P42=9000|9001` means `OR` (same as before)

Implementation:
* query parser does not remove empty values
* caller of query parser handles empty values vs single empty string vs having values


https://github.com/user-attachments/assets/b06e36db-f1ce-4c8f-89c9-5472ca69edb2

