### PR TITLE
Reindex item page

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -47,7 +47,8 @@
 		"SpecialSearchResults": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onSpecialSearchResults",
 		"CirrusSearchAddQueryFeatures": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onCirrusSearchAddQueryFeatures",
 		"SearchIndexFields": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onSearchIndexFields",
-		"SearchDataForIndex": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onSearchDataForIndex"
+		"SearchDataForIndex": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onSearchDataForIndex",
+		"PageSaveComplete": "ProfessionalWiki\\WikibaseFacetedSearch\\EntryPoints\\WikibaseFacetedSearchHooks::onPageSaveComplete"
 	},
 
 	"config": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -53,3 +53,9 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Persistence/Search/Query/ListFacetQueryBuilder.php
+
+		-
+			message: '#^Parameter \#1 \$pageIdentity of method MediaWiki\\Page\\WikiPageFactory\:\:newFromTitle\(\) expects MediaWiki\\Page\\PageIdentity, MediaWiki\\Title\\Title\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Persistence/SiteLinkItemPageUpdater.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -53,9 +53,3 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Persistence/Search/Query/ListFacetQueryBuilder.php
-
-		-
-			message: '#^Parameter \#1 \$pageIdentity of method MediaWiki\\Page\\WikiPageFactory\:\:newFromTitle\(\) expects MediaWiki\\Page\\PageIdentity, MediaWiki\\Title\\Title\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Persistence/SiteLinkItemPageUpdater.php

--- a/src/Application/ItemPageUpdater.php
+++ b/src/Application/ItemPageUpdater.php
@@ -1,0 +1,14 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Application;
+
+use MediaWiki\User\UserIdentity;
+use Wikibase\DataModel\Entity\Item;
+
+interface ItemPageUpdater {
+
+	public function updatePage( Item $item, UserIdentity $user ): void;
+
+}

--- a/src/EntryPoints/WikibaseFacetedSearchHooks.php
+++ b/src/EntryPoints/WikibaseFacetedSearchHooks.php
@@ -16,8 +16,11 @@ use MediaWiki\EditPage\EditPage;
 use MediaWiki\Html\Html;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Specials\SpecialSearch;
+use MediaWiki\Storage\EditResult;
 use MediaWiki\Title\Title;
+use MediaWiki\User\UserIdentity;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\ConfigEditPageTextBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\ConfigJsonErrorFormatter;
 use ProfessionalWiki\WikibaseFacetedSearch\WikibaseFacetedSearchExtension;
@@ -25,6 +28,7 @@ use SearchEngine;
 use SearchIndexField;
 use SearchResult;
 use Skin;
+use Wikibase\Repo\Content\ItemContent;
 use WikiPage;
 
 class WikibaseFacetedSearchHooks {
@@ -220,4 +224,20 @@ class WikibaseFacetedSearchHooks {
 		}
 	}
 
+	public static function onPageSaveComplete(
+		WikiPage $wikiPage,
+		UserIdentity $user,
+		string $summary,
+		int $flags,
+		RevisionRecord $revisionRecord,
+		EditResult $editResult
+	) {
+		$content = $wikiPage->getContent();
+
+		if ( !( $content instanceof ItemContent ) ) {
+			return;
+		}
+
+		WikibaseFacetedSearchExtension::getInstance()->newItemPageUpdater()->updatePage( $content->getItem(), $user );
+	}
 }

--- a/src/Persistence/NoOpItemPageUpdater.php
+++ b/src/Persistence/NoOpItemPageUpdater.php
@@ -1,0 +1,17 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence;
+
+use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\ItemPageUpdater;
+use Wikibase\DataModel\Entity\Item;
+
+class NoOpItemPageUpdater implements ItemPageUpdater {
+
+	public function updatePage( Item $item, UserIdentity $user ): void {
+		// Do nothing.
+	}
+
+}

--- a/src/Persistence/SiteLinkItemPageUpdater.php
+++ b/src/Persistence/SiteLinkItemPageUpdater.php
@@ -1,0 +1,36 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence;
+
+use MediaWiki\Page\WikiPageFactory;
+use MediaWiki\Title\Title;
+use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\ItemPageUpdater;
+use Wikibase\DataModel\Entity\Item;
+use WikiPage;
+
+class SiteLinkItemPageUpdater implements ItemPageUpdater {
+
+	public function __construct(
+		private readonly string $linkTargetSitelinkSiteId,
+		private readonly WikiPageFactory $pageFactory
+	) {
+	}
+
+	public function updatePage( Item $item, UserIdentity $user ): void {
+		if ( $item->hasLinkToSite( $this->linkTargetSitelinkSiteId ) ) {
+			$this->getSiteLinkedPage( $item )
+				->newPageUpdater( $user )
+				->updateRevision();
+		}
+	}
+
+	private function getSiteLinkedPage( Item $item ): WikiPage {
+		return $this->pageFactory->newFromTitle(
+			Title::newFromText( $item->getSiteLink( $this->linkTargetSitelinkSiteId )->getPageName() )
+		);
+	}
+
+}

--- a/src/Persistence/SiteLinkItemPageUpdater.php
+++ b/src/Persistence/SiteLinkItemPageUpdater.php
@@ -20,17 +20,23 @@ class SiteLinkItemPageUpdater implements ItemPageUpdater {
 	}
 
 	public function updatePage( Item $item, UserIdentity $user ): void {
-		if ( $item->hasLinkToSite( $this->linkTargetSitelinkSiteId ) ) {
-			$this->getSiteLinkedPage( $item )
-				->newPageUpdater( $user )
-				->updateRevision();
+		$title = $this->getSiteLinkedTitle( $item );
+
+		if ( $title === null ) {
+			return;
 		}
+
+		$this->pageFactory->newFromTitle( $title )
+			->newPageUpdater( $user )
+			->updateRevision();
 	}
 
-	private function getSiteLinkedPage( Item $item ): WikiPage {
-		return $this->pageFactory->newFromTitle(
-			Title::newFromText( $item->getSiteLink( $this->linkTargetSitelinkSiteId )->getPageName() )
-		);
+	private function getSiteLinkedTitle( Item $item ): ?Title {
+		if ( $item->hasLinkToSite( $this->linkTargetSitelinkSiteId ) ) {
+			return Title::newFromText( $item->getSiteLink( $this->linkTargetSitelinkSiteId )->getPageName() );
+		}
+
+		return null;
 	}
 
 }

--- a/src/WikibaseFacetedSearchExtension.php
+++ b/src/WikibaseFacetedSearchExtension.php
@@ -16,6 +16,7 @@ use ProfessionalWiki\WikibaseFacetedSearch\Application\ConfigLookup;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\DataValueTranslator;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ElasticQueryFilter;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\FacetType;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\ItemPageUpdater;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ItemTypeExtractor;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ItemTypeLabelLookup;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\PageItemLookup;
@@ -31,6 +32,8 @@ use ProfessionalWiki\WikibaseFacetedSearch\Persistence\ElasticQueryRunner;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\ElasticValueCounter;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\FallbackItemTypeLabelLookup;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\FromPageStatementsLookup;
+use ProfessionalWiki\WikibaseFacetedSearch\Persistence\NoOpItemPageUpdater;
+use ProfessionalWiki\WikibaseFacetedSearch\Persistence\SiteLinkItemPageUpdater;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\PageContentConfigLookup;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\PageContentFetcher;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\PageItemLookupFactory;
@@ -326,6 +329,17 @@ class WikibaseFacetedSearchExtension {
 
 	public function newElasticQueryFilter(): ElasticQueryFilter {
 		return new ElasticQueryFilter();
+	}
+
+	public function newItemPageUpdater(): ItemPageUpdater {
+		if ( $this->getConfig()->linkTargetSitelinkSiteId === null ) {
+			return new NoOpItemPageUpdater();
+		}
+
+		return new SiteLinkItemPageUpdater(
+			linkTargetSitelinkSiteId: $this->getConfig()->linkTargetSitelinkSiteId,
+			pageFactory: MediaWikiServices::getInstance()->getWikiPageFactory()
+		);
 	}
 
 }


### PR DESCRIPTION
For #59 

This creates a null edit on the linked page. Indexing of the page is then handled by MediaWiki (e.g. $wgJobRunRate or runJobs.php). 