### PR TITLE
Add item type message lookup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
 		"composer/installers": "^2|^1.0.1",
 		"opis/json-schema": "^2.3.0",
 		"ruflin/elastica": "^7.1.0",
-		"psr/log": "^1.1.4"
+		"psr/log": "^1.1.4",
+		"professional-wiki/message-builder": "^1.0.0"
 	},
 	"require-dev": {
 		"phpstan/phpstan": "^2.0.1",

--- a/src/Application/MediaWikiMessageBuilder.php
+++ b/src/Application/MediaWikiMessageBuilder.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Application;
+
+use ProfessionalWiki\MessageBuilder\MessageBuilder;
+use ProfessionalWiki\MessageBuilder\UnknownMessageKey;
+
+class MediaWikiMessageBuilder implements MessageBuilder {
+
+	public function buildMessage( string $messageKey, string ...$arguments ): string {
+		$message = wfMessage( $messageKey, ...$arguments );
+
+		if ( $message->exists() ) {
+			return $message->text();
+		}
+
+		throw new UnknownMessageKey();
+	}
+
+}

--- a/src/Persistence/ConfigDeserializer.php
+++ b/src/Persistence/ConfigDeserializer.php
@@ -51,7 +51,6 @@ class ConfigDeserializer {
 	}
 
 	/**
-	 * TODO: also return $itemTypeConfig['label']
 	 * @param array<string, array> $configPerItemType
 	 */
 	private function newFacetConfigList( array $configPerItemType ): ?FacetConfigList {

--- a/src/Persistence/FallbackItemTypeLabelLookup.php
+++ b/src/Persistence/FallbackItemTypeLabelLookup.php
@@ -16,7 +16,11 @@ class FallbackItemTypeLabelLookup implements ItemTypeLabelLookup {
 	}
 
 	public function getLabel( ItemId $itemType ): string {
-		// TODO: prefer item from internationalized source https://github.com/ProfessionalWiki/WikibaseFacetedSearch/issues/91
+		$message = wfMessage( 'WikibaseFacetedSearch-item-type-' . $itemType->getSerialization() );
+
+		if ( $message->exists() ) {
+			return $message->text();
+		}
 
 		return $this->labelLookup->getLabel( $itemType )?->getText() ?? $itemType->getSerialization();
 	}

--- a/src/Persistence/FallbackItemTypeLabelLookup.php
+++ b/src/Persistence/FallbackItemTypeLabelLookup.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence;
 
+use ProfessionalWiki\MessageBuilder\MessageBuilder;
+use ProfessionalWiki\MessageBuilder\UnknownMessageKey;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ItemTypeLabelLookup;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Services\Lookup\LabelLookup;
@@ -12,17 +14,21 @@ class FallbackItemTypeLabelLookup implements ItemTypeLabelLookup {
 
 	public function __construct(
 		private readonly LabelLookup $labelLookup,
+		private readonly MessageBuilder $messageBuilder,
 	) {
 	}
 
 	public function getLabel( ItemId $itemType ): string {
-		$message = wfMessage( 'WikibaseFacetedSearch-item-type-' . $itemType->getSerialization() );
-
-		if ( $message->exists() ) {
-			return $message->text();
+		try {
+			return $this->getMessage( $itemType );
 		}
+		catch ( UnknownMessageKey ) {
+			return $this->labelLookup->getLabel( $itemType )?->getText() ?? $itemType->getSerialization();
+		}
+	}
 
-		return $this->labelLookup->getLabel( $itemType )?->getText() ?? $itemType->getSerialization();
+	private function getMessage( ItemId $itemType ): string {
+		return $this->messageBuilder->buildMessage( 'WikibaseFacetedSearch-item-type-' . $itemType->getSerialization() );
 	}
 
 }

--- a/src/WikibaseFacetedSearchExtension.php
+++ b/src/WikibaseFacetedSearchExtension.php
@@ -19,6 +19,7 @@ use ProfessionalWiki\WikibaseFacetedSearch\Application\FacetType;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ItemPageUpdater;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ItemTypeExtractor;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ItemTypeLabelLookup;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\MediaWikiMessageBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\PageItemLookup;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\QueryStringParser;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\StatementListTranslator;
@@ -276,7 +277,8 @@ class WikibaseFacetedSearchExtension {
 
 	private function getItemTypeLabelLookup( Language $language ): ItemTypeLabelLookup {
 		return new FallbackItemTypeLabelLookup(
-			labelLookup: $this->getLabelLookup( $language )
+			labelLookup: $this->getLabelLookup( $language ),
+			messageBuilder: new MediaWikiMessageBuilder()
 		);
 	}
 

--- a/src/config-example.json
+++ b/src/config-example.json
@@ -3,7 +3,6 @@
 	"itemTypeProperty": "P42",
 	"configPerItemType": {
 		"Q100": {
-			"label": "Memes",
 			"facets": {
 				"P1": {
 					"type": "list"
@@ -14,7 +13,6 @@
 			}
 		},
 		"Q200": {
-			"label": "Cat Pictures",
 			"facets": {
 				"P2": {
 					"type": "range"

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -18,11 +18,8 @@
 			"additionalProperties": {
 				"type": "object",
 				"additionalProperties": false,
-				"required": [ "label", "facets" ],
+				"required": [ "facets" ],
 				"properties": {
-					"label": {
-						"type": "string"
-					},
 					"facets": {
 						"type": "object",
 						"propertyNames": {

--- a/tests/phpunit/Application/MediaWikiMessageBuilderTest.php
+++ b/tests/phpunit/Application/MediaWikiMessageBuilderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\MessageBuilder\UnknownMessageKey;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\MediaWikiMessageBuilder;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseFacetedSearch\Application\MediaWikiMessageBuilder
+ */
+class MediaWikiMessageBuilderTest extends TestCase {
+
+	public function testBuildMessage(): void {
+		$builder = new MediaWikiMessageBuilder();
+
+		$this->assertSame(
+			'Your changes were not saved. They contain the following errors:',
+			$builder->buildMessage( 'wikibase-faceted-search-config-invalid', '2' )
+		);
+	}
+
+	public function testReturnsEmptyStringOnMessageNotFound(): void {
+		$builder = new MediaWikiMessageBuilder();
+
+		$this->expectException( UnknownMessageKey::class );
+		$builder->buildMessage( 'wikibase-faceted-search-does-not-exist-404' );
+	}
+
+}

--- a/tests/phpunit/Persistence/ConfigDeserializerTest.php
+++ b/tests/phpunit/Persistence/ConfigDeserializerTest.php
@@ -88,7 +88,6 @@ class ConfigDeserializerTest extends TestCase {
 		$config = $deserializer->deserialize( '{
 	"configPerItemType": {
 		"Q200": {
-			"label": "Cat Pictures",
 			"facets": {
 				"P2": {
 					"type": "list"
@@ -127,7 +126,6 @@ class ConfigDeserializerTest extends TestCase {
 		$config = $deserializer->deserialize( '{
 	"configPerItemType": {
 		"Q200": {
-			"label": "Cat Pictures",
 			"facets": {
 				"P2": {
 					"type": "list"

--- a/tests/phpunit/Persistence/ConfigJsonValidatorTest.php
+++ b/tests/phpunit/Persistence/ConfigJsonValidatorTest.php
@@ -95,7 +95,6 @@ class ConfigJsonValidatorTest extends TestCase {
 {
 	"configPerItemType": {
 		"P1": {
-			"label": "Memes",
 			"facets": []
 		}
 	}
@@ -122,7 +121,6 @@ class ConfigJsonValidatorTest extends TestCase {
 {
 	"configPerItemType": {
 		"Q1": {
-			"label": "Memes",
 			"facets": {
 				"invalid": {
 					"type": "list"
@@ -141,7 +139,6 @@ class ConfigJsonValidatorTest extends TestCase {
 {
 	"configPerItemType": {
 		"Q1": {
-			"label": "Memes",
 			"facets": {
 				"P1": {
 					"type": "invalid"
@@ -168,7 +165,6 @@ class ConfigJsonValidatorTest extends TestCase {
 {
 	"configPerItemType": {
 		"Q1": {
-			"label": "Memes",
 			"facets": {
 				"P1": {
 					"type": "list",
@@ -188,7 +184,6 @@ class ConfigJsonValidatorTest extends TestCase {
 {
 	"configPerItemType": {
 		"Q1": {
-			"label": "Memes",
 			"facets": {
 				"P1": {
 					"type": "list",
@@ -211,7 +206,6 @@ class ConfigJsonValidatorTest extends TestCase {
 {
 	"configPerItemType": {
 		"Q1": {
-			"label": "Memes",
 			"facets": {
 				"P1": {
 					"type": "list",

--- a/tests/phpunit/Persistence/FallbackItemTypeLabelLookupTest.php
+++ b/tests/phpunit/Persistence/FallbackItemTypeLabelLookupTest.php
@@ -27,4 +27,12 @@ class FallbackItemTypeLabelLookupTest extends TestCase {
 		$this->assertSame( 'Q42', $lookup->getLabel( new ItemId( 'Q42' ) ) );
 	}
 
+	public function testReturnsMessageString(): void {
+		$this->markTestSkipped( 'TODO: set message key' );
+
+		$lookup = new FallbackItemTypeLabelLookup( new StubLabelLookup( label: null ) );
+
+		$this->assertSame( 'People', $lookup->getLabel( new ItemId( 'Q42' ) ) );
+	}
+
 }

--- a/tests/phpunit/Persistence/FallbackItemTypeLabelLookupTest.php
+++ b/tests/phpunit/Persistence/FallbackItemTypeLabelLookupTest.php
@@ -5,9 +5,12 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Persistence;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\MessageBuilder\ArrayMessageBuilder;
+use ProfessionalWiki\MessageBuilder\MessageBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\FallbackItemTypeLabelLookup;
 use ProfessionalWiki\WikibaseFacetedSearch\Tests\TestDoubles\StubLabelLookup;
 use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Services\Lookup\LabelLookup;
 use Wikibase\DataModel\Term\Term;
 
 /**
@@ -15,24 +18,45 @@ use Wikibase\DataModel\Term\Term;
  */
 class FallbackItemTypeLabelLookupTest extends TestCase {
 
-	public function testReturnsTextFromLabelLookup(): void {
-		$lookup = new FallbackItemTypeLabelLookup( new StubLabelLookup( label: new Term( 'whatever', 'expected' ) ) );
+	public function testReturnsMediaWikiMessageIfItExists(): void {
+		$lookup = $this->newLookup( messageBuilder: new ArrayMessageBuilder( [
+			'WikibaseFacetedSearch-item-type-Q41' => 'Cats',
+			'WikibaseFacetedSearch-item-type-Q42' => 'People',
+			'WikibaseFacetedSearch-item-type-Q43' => 'Dogs',
+		] ) );
 
-		$this->assertSame( 'expected', $lookup->getLabel( new ItemId( 'Q42' ) ) );
+		$this->assertSame(
+			'People',
+			$lookup->getLabel( new ItemId( 'Q42' ) )
+		);
 	}
 
-	public function testReturnsIdSerializationWhenLabelLookupReturnsNull(): void {
-		$lookup = new FallbackItemTypeLabelLookup( new StubLabelLookup( label: null ) );
-
-		$this->assertSame( 'Q42', $lookup->getLabel( new ItemId( 'Q42' ) ) );
+	private function newLookup(
+		?LabelLookup $labelLookup = null,
+		?MessageBuilder $messageBuilder = null
+	): FallbackItemTypeLabelLookup {
+		return new FallbackItemTypeLabelLookup(
+			labelLookup: $labelLookup ?? new StubLabelLookup( label: null ),
+			messageBuilder: $messageBuilder ?? new ArrayMessageBuilder( [] )
+		);
 	}
 
-	public function testReturnsMessageString(): void {
-		$this->markTestSkipped( 'TODO: set message key' );
+	public function testReturnsTextFromLabelLookupAsFallback(): void {
+		$lookup = $this->newLookup( new StubLabelLookup( label: new Term( 'whatever', 'expected' ) ) );
 
-		$lookup = new FallbackItemTypeLabelLookup( new StubLabelLookup( label: null ) );
+		$this->assertSame(
+			'expected',
+			$lookup->getLabel( new ItemId( 'Q42' ) )
+		);
+	}
 
-		$this->assertSame( 'People', $lookup->getLabel( new ItemId( 'Q42' ) ) );
+	public function testReturnsIdSerializationAsFinalFallback(): void {
+		$lookup = $this->newLookup( new StubLabelLookup( label: null ) );
+
+		$this->assertSame(
+			'Q42',
+			$lookup->getLabel( new ItemId( 'Q42' ) )
+		);
 	}
 
 }

--- a/tests/phpunit/Presentation/SidebarHtmlBuilderIntegrationTest.php
+++ b/tests/phpunit/Presentation/SidebarHtmlBuilderIntegrationTest.php
@@ -25,7 +25,6 @@ class SidebarHtmlBuilderIntegrationTest extends MediaWikiIntegrationTestCase {
 	"itemTypeProperty": "P42",
 	"configPerItemType": {
 		"Q1": {
-			"label": "People",
 			"facets": {
 				"P100": {
 					"type": "range"

--- a/tests/phpunit/Presentation/TabsHtmlBuilderUnitTest.php
+++ b/tests/phpunit/Presentation/TabsHtmlBuilderUnitTest.php
@@ -54,7 +54,6 @@ class TabsHtmlBuilderUnitTest extends TestCase {
 	"itemTypeProperty": "P1337",
 	"configPerItemType": {
 		"Q5976445": {
-			"label": "People",
 			"facets": {
 				"P592": {
 					"type": "list"
@@ -65,7 +64,6 @@ class TabsHtmlBuilderUnitTest extends TestCase {
 			}
 		},
 		"Q5976449": {
-			"label": "Documents",
 			"facets": {
 				"P22": {
 					"type": "list"
@@ -109,15 +107,12 @@ JSON );
 	"itemTypeProperty": "P1337",
 	"configPerItemType": {
 		"Q1": {
-			"label": "whatever1",
 			"facets": { "P1": { "type": "list" } }
 		},
 		"Q2": {
-			"label": "whatever2",
 			"facets": { "P1": { "type": "list" } }
 		},
 		"Q3": {
-			"label": "whatever3",
 			"facets": { "P1": { "type": "list" } }
 		}
 	}

--- a/tests/phpunit/Valid.php
+++ b/tests/phpunit/Valid.php
@@ -22,7 +22,6 @@ class Valid {
     "itemTypeProperty": "P42",
     "configPerItemType": {
         "Q100": {
-            "label": "Memes",
             "facets": {
                 "P1": {
                     "type": "list"
@@ -33,7 +32,6 @@ class Valid {
             }
         },
         "Q200": {
-            "label": "Cat Pictures",
             "facets": {
                 "P3": {
                     "type": "list"


### PR DESCRIPTION
For #91 

Uses an automatic message key lookup based on the Item ID: `MediaWiki:WikibaseFacetedSearch-item-type-Q42`