### PR TITLE
Sort selected facet values to the top

### DIFF
--- a/src/Presentation/ListFacetHtmlBuilder.php
+++ b/src/Presentation/ListFacetHtmlBuilder.php
@@ -105,6 +105,14 @@ class ListFacetHtmlBuilder implements FacetHtmlBuilder {
 	}
 
 	private function buildCheckboxesViewModel( FacetConfig $config, PropertyConstraints $state, array $valueCounts ): array {
+		if ( $valueCounts === [] ) {
+			return [
+				'visible' => [],
+				'collapsed' => [],
+				'showMore' => false
+			];
+		}
+
 		$maxVisibleCheckboxes = 5; // TODO: Make this configurable
 		$combineWithAnd = $this->shouldCombineWithAnd( $config, $state );
 
@@ -118,6 +126,8 @@ class ListFacetHtmlBuilder implements FacetHtmlBuilder {
 		foreach ( $valueCounts as $i => $valueCount ) {
 			$checkboxes[] = $this->buildCheckboxViewModel( $config, $valueCount, $selectedValues, $state->propertyId, $i );
 		}
+
+		usort( $checkboxes, fn( $a, $b ) => $b['checked'] <=> $a['checked'] );
 
 		return [
 			'visible' => array_slice( $checkboxes, 0, $maxVisibleCheckboxes ),

--- a/tests/phpunit/Presentation/ListFacetHtmlBuilderTest.php
+++ b/tests/phpunit/Presentation/ListFacetHtmlBuilderTest.php
@@ -102,13 +102,16 @@ class ListFacetHtmlBuilderTest extends TestCase {
 				->withAdditionalAndValue( StubValueCounter::SIXTH_VALUE )
 		);
 
-		$this->assertFalse( $viewModel['checkboxes']['visible'][0]['checked'] );
+		$this->assertTrue( $viewModel['checkboxes']['visible'][0]['checked'] );
+		$this->assertSame( StubValueCounter::SECOND_VALUE, $viewModel['checkboxes']['visible'][0]['value'] );
 		$this->assertTrue( $viewModel['checkboxes']['visible'][1]['checked'] );
+		$this->assertSame( StubValueCounter::SIXTH_VALUE, $viewModel['checkboxes']['visible'][1]['value'] );
+
 		$this->assertFalse( $viewModel['checkboxes']['visible'][2]['checked'] );
 		$this->assertFalse( $viewModel['checkboxes']['visible'][3]['checked'] );
 		$this->assertFalse( $viewModel['checkboxes']['visible'][4]['checked'] );
 
-		$this->assertTrue( $viewModel['checkboxes']['collapsed'][0]['checked'] );
+		$this->assertFalse( $viewModel['checkboxes']['collapsed'][0]['checked'] );
 		$this->assertFalse( $viewModel['checkboxes']['collapsed'][1]['checked'] );
 	}
 
@@ -123,13 +126,16 @@ class ListFacetHtmlBuilderTest extends TestCase {
 			typeSpecificConfig: [ 'defaultCombineWith' => 'OR' ]
 		);
 
-		$this->assertFalse( $viewModel['checkboxes']['visible'][0]['checked'] );
+		$this->assertTrue( $viewModel['checkboxes']['visible'][0]['checked'] );
+		$this->assertSame( StubValueCounter::SECOND_VALUE, $viewModel['checkboxes']['visible'][0]['value'] );
 		$this->assertTrue( $viewModel['checkboxes']['visible'][1]['checked'] );
+		$this->assertSame( StubValueCounter::SIXTH_VALUE, $viewModel['checkboxes']['visible'][1]['value'] );
+
 		$this->assertFalse( $viewModel['checkboxes']['visible'][2]['checked'] );
 		$this->assertFalse( $viewModel['checkboxes']['visible'][3]['checked'] );
 		$this->assertFalse( $viewModel['checkboxes']['visible'][4]['checked'] );
 
-		$this->assertTrue( $viewModel['checkboxes']['collapsed'][0]['checked'] );
+		$this->assertFalse( $viewModel['checkboxes']['collapsed'][0]['checked'] );
 		$this->assertFalse( $viewModel['checkboxes']['collapsed'][1]['checked'] );
 	}
 

--- a/tests/phpunit/Presentation/ListFacetHtmlBuilderTest.php
+++ b/tests/phpunit/Presentation/ListFacetHtmlBuilderTest.php
@@ -72,6 +72,20 @@ class ListFacetHtmlBuilderTest extends TestCase {
 		);
 	}
 
+	public function testCheckboxesViewModelContainsNoValues(): void {
+		$viewModel = $this->buildViewModel(
+			valueCounter: new SequentialValueCounter( 0 )
+		);
+
+		$this->assertArrayHasKey( 'visible', $viewModel['checkboxes'] );
+		$this->assertArrayHasKey( 'collapsed', $viewModel['checkboxes'] );
+		$this->assertArrayHasKey( 'showMore', $viewModel['checkboxes'] );
+
+		$this->assertCount( 0, $viewModel['checkboxes']['visible'] );
+		$this->assertCount( 0, $viewModel['checkboxes']['collapsed'] );
+		$this->assertFalse( $viewModel['checkboxes']['showMore'] );
+	}
+
 	public function testCheckboxesViewModelContainsAllValues(): void {
 		$viewModel = $this->buildViewModel();
 


### PR DESCRIPTION
#177

Key changes:
* Sort checkboxes to prioritize checked items
* Add an early exit in `buildCheckboxesViewModel` when there are no facet values (Unsure about this since theoretically this should not happen with #185)
* Update tests to reflect new sorting behavior

![image](https://github.com/user-attachments/assets/b0fbc3cf-ce1b-4ae1-bee5-8994090ea0fe)
