### PR TITLE
Add item type labels to config documentation

### DIFF
--- a/resources/ext.wikibase.facetedsearch.docs.less
+++ b/resources/ext.wikibase.facetedsearch.docs.less
@@ -1,3 +1,16 @@
+@import 'mediawiki.skin.variables.less';
+
 #Documentation pre {
 	tab-size: 4;
+}
+
+.wikibase-faceted-search-config-help {
+	&__itemtypes-table {
+		width: 100%;
+	}
+
+	&__itemtypes-table-action {
+		float: right;
+		margin-left: @spacing-100;
+	}
 }

--- a/src/EntryPoints/WikibaseFacetedSearchHooks.php
+++ b/src/EntryPoints/WikibaseFacetedSearchHooks.php
@@ -147,7 +147,9 @@ class WikibaseFacetedSearchHooks {
 
 			$textBuilder = new ConfigEditPageTextBuilder(
 				context: $editPage->getContext(),
-				exampleConfigPath: WikibaseFacetedSearchExtension::getInstance()->getExampleConfigPath()
+				exampleConfigPath: WikibaseFacetedSearchExtension::getInstance()->getExampleConfigPath(),
+				templateParser: WikibaseFacetedSearchExtension::getInstance()->getTemplateParser(),
+				config: WikibaseFacetedSearchExtension::getInstance()->getConfig()
 			);
 			$editPage->editFormTextTop = $textBuilder->createTopHtml();
 			$editPage->editFormTextBottom = $textBuilder->createBottomHtml();

--- a/templates/ConfigEditPageBottom.mustache
+++ b/templates/ConfigEditPageBottom.mustache
@@ -1,0 +1,93 @@
+<div id="Documentation">
+    <section>
+        <h2 id="ConfigurationDocumentation">{{msg-wikibase-faceted-search-config-help}}</h2>
+
+        <p>
+            Besides the configuration reference below, you can consult the Wikibase Faceted Search
+            <a href="https://professional.wiki/en/extension/wikibase-faceted-search">usage documentation</a> and
+            <a href="https://facetedsearch.wikibase.wiki">demo wiki</a>.
+        </p>
+    </section>
+
+    <section>
+        <h2 id="sitelinkSiteId">Link target sitelink site ID</h2>
+
+        <p>
+            By default search result items link to their item page (<code>Item:Q123</code>).
+        </p>
+
+        <p>
+            You can change the link to use a sitelink of the item instead.
+        </p>
+
+        <p>
+            Example configuration:
+        </p>
+
+        <pre>
+{
+	"sitelinkSiteId": "enwiki"
+}</pre>
+    </section>
+
+    <section>
+        <h2 id="ItemTypeProperty">Instance Of property ID</h2>
+
+        <p>
+            The property ID for the "instance of" property.
+        </p>
+
+        <p>
+            Example configuration:
+        </p>
+
+        <pre>
+{
+	"itemTypeProperty": "P1"
+}</pre>
+    </section>
+
+    <section>
+        <h2 id="Facets">Facets</h2>
+
+        <p>
+            The available facets per item type ("instance of"). Each facet is defined by a property ID and a type.
+        </p>
+
+        <p>
+            Example configuration:
+        </p>
+
+        <pre>
+{
+	"facets": {
+		"Q1": [
+			{
+				"property": "P1",
+				"type": "list"
+			},
+			{
+				"property": "P2",
+				"type": "range"
+			}
+		]
+	}
+}</pre>
+		<h3>Item type labels</h3>
+		<p>
+			You can add a label to an item type by editing the <code>MediaWiki:WikibaseFacetedSearch-item-type-Q{N}</code> page.
+			Replace <code>{N}</code> with the numeric ID of the item type (<code>MediaWiki:WikibaseFacetedSearch-item-type-Q1</code> for <code>Q1</code>).
+		</p>
+		<p>
+			To add a label in a different language, edit the subpage of the page you created above (<code>MediaWiki:WikibaseFacetedSearch-item-type-Q1/de</code> for German).
+		</p>
+
+		{{>ConfigEditPageItemTypesTable}}
+    </section>
+
+    <section>
+        <h2 id="FullExample">{{msg-wikibase-faceted-search-config-help-example}}</h2>
+
+        <pre>{{exampleContents}}</pre>
+    </section>
+</div> 

--- a/templates/ConfigEditPageItemTypesTable.mustache
+++ b/templates/ConfigEditPageItemTypesTable.mustache
@@ -1,0 +1,30 @@
+<table class="wikibase-faceted-search-config-help__itemtypes-table wikitable">
+    <thead>
+        <tr>
+            <th scope="col">ID</th>
+            <th scope="col">Label</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{#array-itemTypes}}
+            <tr>
+                <td>{{id}}</td>
+                <td>
+                    {{#label}}
+                        {{.}}
+                    {{/label}}
+                    {{^label}}
+                        <em>No label defined</em>
+                    {{/label}}
+                    <a
+                        class="wikibase-faceted-search-config-help__itemtypes-table-action"
+                        href="{{wgScript}}?title=MediaWiki:WikibaseFacetedSearch-item-type-{{id}}&action=edit"
+                        title="{{action}} label for {{id}}"
+                    >
+                        {{action}}
+                    </a>
+                </td>
+            </tr>
+        {{/array-itemTypes}}
+    </tbody>
+</table>

--- a/templates/ConfigEditPageTop.mustache
+++ b/templates/ConfigEditPageTop.mustache
@@ -1,0 +1,3 @@
+<div id="wikibase-faceted-search-config-help-top">
+    <p>{{{msg-wikibase-faceted-search-config-help-documentation}}}</p>
+</div> 

--- a/tests/phpunit/Presentation/ConfigPageTest.php
+++ b/tests/phpunit/Presentation/ConfigPageTest.php
@@ -41,6 +41,12 @@ class ConfigPageTest extends WikibaseFacetedSearchIntegrationTest {
 			'Configuration documentation',
 			$html
 		);
+
+		// Item types table
+		$this->assertStringContainsString(
+			'wikibase-faceted-search-config-help__itemtypes-table',
+			$html
+		);
 	}
 
 	public function testEditingTabShowsDefaultValues(): void {


### PR DESCRIPTION
Closes: #198

Key changes:
- Add item type label section
- Refactor config documentation into Mustache
- Fix minor typo

![image](https://github.com/user-attachments/assets/02667f7d-177a-4fe4-a4da-e9d93e27a5cb)
