### PR TITLE
Add Font Awesome icon support to tab name

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,7 +7,13 @@ parameters:
 			path: src/Persistence/ConfigDeserializer.php
 
 		-
-			message: '#^Parameter \#1 \$configPerItemType of method ProfessionalWiki\\WikibaseFacetedSearch\\Persistence\\ConfigDeserializer\:\:newFacetConfigList\(\) expects array\<string, array\>, mixed given\.$#'
+			message: '#^Parameter \#1 \$configPerItemType of method ProfessionalWiki\\WikibaseFacetedSearch\\Persistence\\ConfigDeserializer\:\:newFacetConfigList\(\) expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Persistence/ConfigDeserializer.php
+
+		-
+			message: '#^Parameter \#1 \$configPerItemType of method ProfessionalWiki\\WikibaseFacetedSearch\\Persistence\\ConfigDeserializer\:\:newIconsList\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Persistence/ConfigDeserializer.php

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -18,6 +18,12 @@
 			flex-grow: 1;
 		}
 
+		.wikibase-faceted-search__instance {
+			display: flex;
+			align-items: center;
+			gap: @spacing-25;
+		}
+
 		.wikibase-faceted-search__settings-button {
 			flex-shrink: 0;
 

--- a/src/Application/Config.php
+++ b/src/Application/Config.php
@@ -14,7 +14,7 @@ class Config {
 		public readonly ?string $sitelinkSiteId = null,
 		private readonly ?PropertyId $itemTypeProperty = null,
 		private readonly ?FacetConfigList $facets = null,
-		private readonly ?array $icons = null
+		private readonly ?array $icons = null,
 	) {
 	}
 
@@ -23,7 +23,7 @@ class Config {
 			$config->sitelinkSiteId ?? $this->sitelinkSiteId,
 			$config->itemTypeProperty ?? $this->itemTypeProperty,
 			$config->facets ?? $this->facets,
-			$config->icons ?? $this->icons
+			$config->icons ?? $this->icons,
 		);
 	}
 

--- a/src/Application/Config.php
+++ b/src/Application/Config.php
@@ -13,7 +13,8 @@ class Config {
 	public function __construct(
 		public readonly ?string $sitelinkSiteId = null,
 		private readonly ?PropertyId $itemTypeProperty = null,
-		private readonly ?FacetConfigList $facets = null
+		private readonly ?FacetConfigList $facets = null,
+		private readonly ?array $icons = null
 	) {
 	}
 
@@ -21,7 +22,8 @@ class Config {
 		return new Config(
 			$config->sitelinkSiteId ?? $this->sitelinkSiteId,
 			$config->itemTypeProperty ?? $this->itemTypeProperty,
-			$config->facets ?? $this->facets
+			$config->facets ?? $this->facets,
+			$config->icons ?? $this->icons
 		);
 	}
 
@@ -35,6 +37,10 @@ class Config {
 
 	public function getFacets(): FacetConfigList {
 		return $this->facets ?? new FacetConfigList();
+	}
+
+	public function getIconForItemType( ItemId $itemType ): ?string {
+		return $this->icons[$itemType->getSerialization()] ?? null;
 	}
 
 	/**

--- a/src/Persistence/ConfigDeserializer.php
+++ b/src/Persistence/ConfigDeserializer.php
@@ -39,7 +39,7 @@ class ConfigDeserializer {
 			sitelinkSiteId: $configArray['sitelinkSiteId'] ?? null,
 			itemTypeProperty: $this->newPropertyId( $configArray['itemTypeProperty'] ?? null ),
 			facets: $this->newFacetConfigList( $configArray['configPerItemType'] ?? [] ),
-			icons: $this->newIconsList( $configArray['configPerItemType'] ?? [] )
+			icons: $this->newIconsList( $configArray['configPerItemType'] ?? [] ),
 		);
 	}
 

--- a/src/Persistence/ConfigDeserializer.php
+++ b/src/Persistence/ConfigDeserializer.php
@@ -35,10 +35,16 @@ class ConfigDeserializer {
 	 * @param array<string, mixed> $configArray
 	 */
 	private function newConfig( array $configArray ): Config {
+		// Need to stop phpstan from complaining about the type of $configPerItemType
+		$configPerItemType = isset( $configArray['configPerItemType'] ) && is_array( $configArray['configPerItemType'] )
+			? $configArray['configPerItemType']
+			: [];
+
 		return new Config(
 			sitelinkSiteId: $configArray['sitelinkSiteId'] ?? null,
 			itemTypeProperty: $this->newPropertyId( $configArray['itemTypeProperty'] ?? null ),
-			facets: $this->newFacetConfigList( $configArray['configPerItemType'] ?? [] )
+			facets: $this->newFacetConfigList( $configPerItemType ),
+			icons: $this->newIconsList( $configPerItemType )
 		);
 	}
 
@@ -50,9 +56,24 @@ class ConfigDeserializer {
 		return new NumericPropertyId( $propertyId );
 	}
 
-	/**
-	 * @param array<string, array> $configPerItemType
-	 */
+	private function newIconsList( array $configPerItemType ): ?array {
+		if ( $configPerItemType === [] ) {
+			return null;
+		}
+
+		$icons = [];
+
+		foreach ( $configPerItemType as $itemId => $itemTypeConfig ) {
+			if ( !isset( $itemTypeConfig['icon'] ) ) {
+				continue;
+			}
+
+			$icons[$itemId] = $itemTypeConfig['icon'];
+		}
+
+		return $icons === [] ? null : $icons;
+	}
+
 	private function newFacetConfigList( array $configPerItemType ): ?FacetConfigList {
 		if ( $configPerItemType === [] ) {
 			return null;

--- a/src/Persistence/ConfigDeserializer.php
+++ b/src/Persistence/ConfigDeserializer.php
@@ -35,16 +35,11 @@ class ConfigDeserializer {
 	 * @param array<string, mixed> $configArray
 	 */
 	private function newConfig( array $configArray ): Config {
-		// Need to stop phpstan from complaining about the type of $configPerItemType
-		$configPerItemType = isset( $configArray['configPerItemType'] ) && is_array( $configArray['configPerItemType'] )
-			? $configArray['configPerItemType']
-			: [];
-
 		return new Config(
 			sitelinkSiteId: $configArray['sitelinkSiteId'] ?? null,
 			itemTypeProperty: $this->newPropertyId( $configArray['itemTypeProperty'] ?? null ),
-			facets: $this->newFacetConfigList( $configPerItemType ),
-			icons: $this->newIconsList( $configPerItemType )
+			facets: $this->newFacetConfigList( $configArray['configPerItemType'] ?? [] ),
+			icons: $this->newIconsList( $configArray['configPerItemType'] ?? [] )
 		);
 	}
 
@@ -57,10 +52,6 @@ class ConfigDeserializer {
 	}
 
 	private function newIconsList( array $configPerItemType ): ?array {
-		if ( $configPerItemType === [] ) {
-			return null;
-		}
-
 		$icons = [];
 
 		foreach ( $configPerItemType as $itemId => $itemTypeConfig ) {

--- a/src/Presentation/FontAwesomeIconBuilder.php
+++ b/src/Presentation/FontAwesomeIconBuilder.php
@@ -1,0 +1,67 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Presentation;
+
+use MediaWiki\Html\Html;
+
+/**
+ * This only supports the CSS Pseudo-elements method for Font Awesome
+ * @see https://docs.fontawesome.com/web/add-icons/pseudo-elements
+ *
+ * TODO: Look into a proper implementation with Extension:FontAwesome
+ * after updating that extension.
+ */
+class FontAwesomeIconBuilder implements IconBuilder {
+
+	/**
+	 * Mapping of style names to their short form classes
+	 * TODO: Remove this once Extension:FontAwesome is updated to Font Awesome 6
+	 *
+	 * @see https://docs.fontawesome.com/web/setup/upgrade/whats-changed#full-style-names
+	 */
+	private const STYLE_SHORT_FORMS = [
+		'solid' => 'fas',
+		'regular' => 'far',
+		'light' => 'fal',
+		'thin' => 'fat',
+		'duotone' => 'fad',
+		'sharp-solid' => 'fass',
+		'sharp-regular' => 'fasr',
+		'sharp-light' => 'fasl',
+		'sharp-thin' => 'fast',
+		'brands' => 'fab',
+	];
+
+	public function __construct(
+		private readonly string $style = 'solid',
+		private readonly string $family = 'classic'
+	) {
+	}
+
+	public function buildHtml( string $iconName, ?array $options = [] ): string {
+		$family = $options['family'] ?? $this->family;
+		$style = $options['style'] ?? $this->style;
+
+		$classes = [
+			'wikibase-faceted-search__icon-fontawesome',
+			"fa-$style",
+			"fa-$iconName"
+		];
+
+		if ( isset( self::STYLE_SHORT_FORMS[$style] ) ) {
+			$classes[] = self::STYLE_SHORT_FORMS[$style];
+		}
+
+		// Font Awesome omits the family class for the 'classic' style
+		if ( $family !== 'classic' ) {
+			$classes[] = "fa-$family";
+		}
+
+		return Html::element( 'span', [
+			'class' => implode( ' ', $classes )
+		] );
+	}
+
+}

--- a/src/Presentation/FontAwesomeIconBuilder.php
+++ b/src/Presentation/FontAwesomeIconBuilder.php
@@ -36,7 +36,7 @@ class FontAwesomeIconBuilder implements IconBuilder {
 
 	public function __construct(
 		private readonly string $style = 'solid',
-		private readonly string $family = 'classic'
+		private readonly string $family = 'classic',
 	) {
 	}
 
@@ -47,7 +47,7 @@ class FontAwesomeIconBuilder implements IconBuilder {
 		$classes = [
 			'wikibase-faceted-search__icon-fontawesome',
 			"fa-$style",
-			"fa-$iconName"
+			"fa-$iconName",
 		];
 
 		if ( isset( self::STYLE_SHORT_FORMS[$style] ) ) {

--- a/src/Presentation/IconBuilder.php
+++ b/src/Presentation/IconBuilder.php
@@ -1,0 +1,11 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Presentation;
+
+interface IconBuilder {
+
+	public function buildHtml( string $iconName, ?array $options = [] ): string;
+
+}

--- a/src/Presentation/TabsHtmlBuilder.php
+++ b/src/Presentation/TabsHtmlBuilder.php
@@ -106,11 +106,11 @@ class TabsHtmlBuilder {
 	private function buildTabIcon( ItemId $itemType ): ?string {
 		$icon = $this->config->getIconForItemType( $itemType );
 
-		if ( $icon ) {
-			return $this->iconBuilder->buildHtml( $icon );
+		if ( $icon === null ) {
+			return null;
 		}
 
-		return null;
+		return $this->iconBuilder->buildHtml( $icon );
 	}
 
 	private function noTabsAreSelected( array $tabs ): bool {

--- a/src/Presentation/TabsHtmlBuilder.php
+++ b/src/Presentation/TabsHtmlBuilder.php
@@ -23,7 +23,8 @@ class TabsHtmlBuilder {
 		private readonly TemplateParser $templateParser,
 		private readonly QueryStringParser $queryStringParser,
 		private readonly ConfigAuthorizer $configAuthorizer,
-		private readonly TitleFactory $titleFactory
+		private readonly TitleFactory $titleFactory,
+		private readonly IconBuilder $iconBuilder
 	) {
 	}
 
@@ -74,11 +75,7 @@ class TabsHtmlBuilder {
 		$tabs = [];
 
 		foreach ( $this->config->getItemTypes() as $itemType ) {
-			$tabs[] = [
-				'label' => $this->itemTypeLabelLookup->getLabel( $itemType ),
-				'value' => $itemType->getSerialization(),
-				'selected' => $itemType->equals( $selectedItemType )
-			];
+			$tabs[] = $this->buildTabViewModel( $itemType, $selectedItemType );
 		}
 
 		return [
@@ -91,9 +88,31 @@ class TabsHtmlBuilder {
 		];
 	}
 
-	/**
-	 * @param array<array{selected: bool}> $tabs
-	 */
+	private function buildTabViewModel( ItemId $itemType, ?ItemId $selectedItemType ): array {
+		$tab = [	
+			'label' => $this->itemTypeLabelLookup->getLabel( $itemType ),
+			'value' => $itemType->getSerialization(),
+			'selected' => $itemType->equals( $selectedItemType )
+		];
+
+		$icon = $this->buildTabIcon( $itemType );
+		if ( $icon !== null ) {
+			$tab['icon'] = $icon;
+		}
+
+		return $tab;
+	}
+
+	private function buildTabIcon( ItemId $itemType ): ?string {
+		$icon = $this->config->getIconForItemType( $itemType );
+
+		if ( $icon ) {
+			return $this->iconBuilder->buildHtml( $icon );
+		}
+
+		return null;
+	}
+
 	private function noTabsAreSelected( array $tabs ): bool {
 		return !array_reduce( $tabs, ( fn( $carry, $tab ) => $carry || $tab['selected'] ), false );
 	}

--- a/src/Presentation/TabsHtmlBuilder.php
+++ b/src/Presentation/TabsHtmlBuilder.php
@@ -24,7 +24,7 @@ class TabsHtmlBuilder {
 		private readonly QueryStringParser $queryStringParser,
 		private readonly ConfigAuthorizer $configAuthorizer,
 		private readonly TitleFactory $titleFactory,
-		private readonly IconBuilder $iconBuilder
+		private readonly IconBuilder $iconBuilder,
 	) {
 	}
 
@@ -92,7 +92,7 @@ class TabsHtmlBuilder {
 		$tab = [	
 			'label' => $this->itemTypeLabelLookup->getLabel( $itemType ),
 			'value' => $itemType->getSerialization(),
-			'selected' => $itemType->equals( $selectedItemType )
+			'selected' => $itemType->equals( $selectedItemType ),
 		];
 
 		$icon = $this->buildTabIcon( $itemType );

--- a/src/WikibaseFacetedSearchExtension.php
+++ b/src/WikibaseFacetedSearchExtension.php
@@ -343,7 +343,7 @@ class WikibaseFacetedSearchExtension {
 			queryStringParser: $this->getQueryStringParser(),
 			configAuthorizer: $this->newConfigAuthorizer( $user ),
 			titleFactory: $this->getTitleFactory(),
-			iconBuilder: $this->newIconBuilder()
+			iconBuilder: $this->newIconBuilder(),
 		);
 	}
 

--- a/src/WikibaseFacetedSearchExtension.php
+++ b/src/WikibaseFacetedSearchExtension.php
@@ -53,6 +53,8 @@ use ProfessionalWiki\WikibaseFacetedSearch\Persistence\SitelinkBasedStatementsLo
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\DelegatingFacetHtmlBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\FacetHtmlBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\FacetValueFormatter;
+use ProfessionalWiki\WikibaseFacetedSearch\Presentation\FontAwesomeIconBuilder;
+use ProfessionalWiki\WikibaseFacetedSearch\Presentation\IconBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\ListFacetHtmlBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\RangeFacetHtmlBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\SidebarHtmlBuilder;
@@ -340,7 +342,8 @@ class WikibaseFacetedSearchExtension {
 			templateParser: $this->getTemplateParser(),
 			queryStringParser: $this->getQueryStringParser(),
 			configAuthorizer: $this->newConfigAuthorizer( $user ),
-			titleFactory: $this->getTitleFactory()
+			titleFactory: $this->getTitleFactory(),
+			iconBuilder: $this->newIconBuilder()
 		);
 	}
 
@@ -349,6 +352,10 @@ class WikibaseFacetedSearchExtension {
 			wikiConfigIsEnabled: (bool)MediaWikiServices::getInstance()->getMainConfig()->get( 'WikibaseFacetedSearchEnableInWikiConfig' ),
 			user: $user
 		);
+	}
+
+	public function newIconBuilder(): IconBuilder {
+		return new FontAwesomeIconBuilder();
 	}
 
 	public function newElasticQueryFilter(): ElasticQueryFilter {

--- a/src/config-example.json
+++ b/src/config-example.json
@@ -3,6 +3,7 @@
 	"itemTypeProperty": "P42",
 	"configPerItemType": {
 		"Q100": {
+			"icon": "person",
 			"facets": {
 				"P1": {
 					"type": "list"
@@ -13,6 +14,7 @@
 			}
 		},
 		"Q200": {
+			"icon": "book",
 			"facets": {
 				"P2": {
 					"type": "range"

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -20,6 +20,9 @@
 				"additionalProperties": false,
 				"required": [ "facets" ],
 				"properties": {
+					"icon": {
+						"type": "string"
+					},
 					"facets": {
 						"type": "object",
 						"propertyNames": {

--- a/templates/Topbar.mustache
+++ b/templates/Topbar.mustache
@@ -16,7 +16,7 @@
 						aria-selected="{{#selected}}true{{/selected}}{{^selected}}false{{/selected}}"
 						value="{{value}}"
 					>
-						{{label}}
+						{{#icon}}{{{.}}}{{/icon}}{{label}}
 					</button>
 				{{/instances}}
 			</div>

--- a/tests/phpunit/Application/ConfigTest.php
+++ b/tests/phpunit/Application/ConfigTest.php
@@ -163,4 +163,21 @@ class ConfigTest extends TestCase {
 		$this->assertTrue( $config->isComplete() );
 	}
 
+	public function testGetIconForItemType(): void {
+		$q1 = new ItemId( 'Q1' );
+		$q2 = new ItemId( 'Q2' );
+		$q3 = new ItemId( 'Q3' );
+
+		$config = new Config(
+			icons: [
+				'Q1' => 'star',
+				'Q2' => 'circle'
+			]
+		);
+
+		$this->assertSame( 'star', $config->getIconForItemType( $q1 ) );
+		$this->assertSame( 'circle', $config->getIconForItemType( $q2 ) );
+		$this->assertNull( $config->getIconForItemType( $q3 ) );
+	}
+
 }

--- a/tests/phpunit/Application/ConfigTest.php
+++ b/tests/phpunit/Application/ConfigTest.php
@@ -171,7 +171,7 @@ class ConfigTest extends TestCase {
 		$config = new Config(
 			icons: [
 				'Q1' => 'star',
-				'Q2' => 'circle'
+				'Q2' => 'circle',
 			]
 		);
 

--- a/tests/phpunit/Presentation/FontAwesomeIconBuilderTest.php
+++ b/tests/phpunit/Presentation/FontAwesomeIconBuilderTest.php
@@ -56,4 +56,10 @@ class FontAwesomeIconBuilderTest extends TestCase {
 		$this->assertStringContainsString( 'fas', $html );
 	}
 
+	public function testBuildHtmlWithClassicFamily(): void {
+		$html = $this->newFontAwesomeIconBuilder( family: 'classic' )->buildHtml( 'bug-slash' );
+
+		$this->assertStringNotContainsString( 'fa-classic', $html );
+	}
+
 }

--- a/tests/phpunit/Presentation/FontAwesomeIconBuilderTest.php
+++ b/tests/phpunit/Presentation/FontAwesomeIconBuilderTest.php
@@ -33,7 +33,7 @@ class FontAwesomeIconBuilderTest extends TestCase {
 	public function testBuildHtmlWithCustomOptions(): void {
 		$html = $this->newFontAwesomeIconBuilder(
 			style: 'regular',
-			family: 'duotone'
+			family: 'duotone',
 		)->buildHtml( 'bug-slash' );
 
 		$this->assertStringContainsString( 'fa-duotone', $html );
@@ -43,7 +43,7 @@ class FontAwesomeIconBuilderTest extends TestCase {
 	public function testBuildHtmlWithCustomLocalOptions(): void {
 		$html = $this->newFontAwesomeIconBuilder()->buildHtml( 'bug-slash', [
 			'style' => 'regular',
-			'family' => 'duotone'
+			'family' => 'duotone',
 		] );
 
 		$this->assertStringContainsString( 'fa-duotone', $html );

--- a/tests/phpunit/Presentation/FontAwesomeIconBuilderTest.php
+++ b/tests/phpunit/Presentation/FontAwesomeIconBuilderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Presentation;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseFacetedSearch\Presentation\FontAwesomeIconBuilder;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseFacetedSearch\Presentation\FontAwesomeIconBuilder
+ */
+class FontAwesomeIconBuilderTest extends TestCase {
+
+	private function newFontAwesomeIconBuilder( ?string $style = null, ?string $family = null ): FontAwesomeIconBuilder {
+		return new FontAwesomeIconBuilder(
+			...array_filter(
+				[ 'style' => $style, 'family' => $family ],
+				fn( $value ) => $value !== null
+			)
+		);
+	}
+
+	public function testBuildHtml(): void {
+		$html = $this->newFontAwesomeIconBuilder()->buildHtml( 'bug-slash' );
+
+		$this->assertStringContainsString( '<span ', $html );
+		$this->assertStringContainsString( 'wikibase-faceted-search__icon-fontawesome', $html );
+		$this->assertStringContainsString( 'fa-solid', $html );
+		$this->assertStringContainsString( 'fa-bug-slash', $html );
+	}
+
+	public function testBuildHtmlWithCustomOptions(): void {
+		$html = $this->newFontAwesomeIconBuilder(
+			style: 'regular',
+			family: 'duotone'
+		)->buildHtml( 'bug-slash' );
+
+		$this->assertStringContainsString( 'fa-duotone', $html );
+		$this->assertStringContainsString( 'fa-regular', $html );
+	}
+
+	public function testBuildHtmlWithCustomLocalOptions(): void {
+		$html = $this->newFontAwesomeIconBuilder()->buildHtml( 'bug-slash', [
+			'style' => 'regular',
+			'family' => 'duotone'
+		] );
+
+		$this->assertStringContainsString( 'fa-duotone', $html );
+		$this->assertStringContainsString( 'fa-regular', $html );
+	}
+
+	public function testBuildHtmlWithDeprecatedStyle(): void {
+		$html = $this->newFontAwesomeIconBuilder( style: 'solid' )->buildHtml( 'bug-slash' );
+
+		$this->assertStringContainsString( 'fas', $html );
+	}
+
+}

--- a/tests/phpunit/Presentation/TabsHtmlBuilderUnitTest.php
+++ b/tests/phpunit/Presentation/TabsHtmlBuilderUnitTest.php
@@ -53,7 +53,8 @@ class TabsHtmlBuilderUnitTest extends TestCase {
 			$templateSpy ?? new SpyTemplateParser(),
 			$queryStringParser ?? new StubQueryStringParser(),
 			$configAuthorizer ?? $this->newConfigAuthorizer(),
-			$titleFactory ?? MediaWikiServices::getInstance()->getTitleFactory()
+			$titleFactory ?? MediaWikiServices::getInstance()->getTitleFactory(),
+			WikibaseFacetedSearchExtension::getInstance()->newIconBuilder()
 		);
 	}
 

--- a/tests/phpunit/Presentation/TabsHtmlBuilderUnitTest.php
+++ b/tests/phpunit/Presentation/TabsHtmlBuilderUnitTest.php
@@ -54,7 +54,7 @@ class TabsHtmlBuilderUnitTest extends TestCase {
 			$queryStringParser ?? new StubQueryStringParser(),
 			$configAuthorizer ?? $this->newConfigAuthorizer(),
 			$titleFactory ?? MediaWikiServices::getInstance()->getTitleFactory(),
-			WikibaseFacetedSearchExtension::getInstance()->newIconBuilder()
+			WikibaseFacetedSearchExtension::getInstance()->newIconBuilder(),
 		);
 	}
 

--- a/tests/phpunit/TestDoubles/StubIconBuilder.php
+++ b/tests/phpunit/TestDoubles/StubIconBuilder.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\TestDoubles;
+
+use ProfessionalWiki\WikibaseFacetedSearch\Presentation\IconBuilder;
+
+class StubIconBuilder implements IconBuilder {
+
+	public function __construct(
+		private readonly string $html = '<span class="test-icon"></span>'
+	) {
+	}
+
+	public function buildHtml( string $iconName, ?array $options = [] ): string {
+		return $this->html;
+	}
+
+}


### PR DESCRIPTION
Related: #209

Key changes:
- Add `IconBuilder` and `FontAwesomeIconBuilder` classes for creating icon HTML
- Add `icon` key to the values of `configPerItemType`. Currently, this is used to define the key for Font Awesome icons

Notes:
- `FontAwesomeIconBuilder` is aimed to support v6, but it should work with v5 as well. It is built that way because the Font Awesome implementation for MW is not great.
[Skin:Chameleon](https://github.com/ProfessionalWiki/chameleon) is on v5, and [Extension:FontAwesome](https://github.com/ProfessionalWiki/FontAwesome) is on v6 but it is still using the old style classes, both are not up-to-date with the latest practices. We should consider updating Extension:FontAwesome to drop the old classes.
- I didn't make Font Awesome an dependency, it is up to the wiki to load Font Awesome since it can be loaded in multiple ways. If the wiki loads Font Awesome through CSS or JS, the extension wouldn't be able to tell.
- The icon configuration works but I am not sure if this is the right approach to it. This might contribute to #107.

To-do:
- Update https://github.com/ProfessionalWiki/mediawiki-dev/tree/wbfs with the new config

![image](https://github.com/user-attachments/assets/b771a9e2-a3c8-415e-9c79-441dfffba973)
