### PR TITLE
Reword Settings button

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -23,7 +23,7 @@
 	"wikibase-faceted-search-instance-type-all": "All",
 
 	"wikibase-faceted-search-filters": "Filters",
-	"wikibase-faceted-search-settings": "Settings",
+	"wikibase-faceted-search-settings": "Configure",
 
 	"wikibase-faceted-search-and": "And",
 	"wikibase-faceted-search-or": "Or",

--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -45,7 +45,7 @@
 		}
 
 		&--settings {
-			.cdx-mixin-css-icon( @cdx-icon-settings, @param-size-icon: @size-icon-small );
+			.cdx-mixin-css-icon( @cdx-icon-edit, @param-size-icon: @size-icon-small );
 		}
 	}
 


### PR DESCRIPTION
New
![image](https://github.com/user-attachments/assets/23dac83f-16ea-4da0-9106-a23ec4ce72cd)

Original
![image](https://github.com/user-attachments/assets/94bf5ef6-9435-403e-ba35-a1b40fa2c672)

## Motivation

We use "configuration" everywhere, not settings. So "configuration" seems better. And since it is a button, "configure" seems better.

I wanted to switch to a wrench icon but could not find. Perhaps this edit one is also good