### PR TITLE
Parse tab name in documentation

### DIFF
--- a/src/Presentation/ConfigDocumentationBuilder.php
+++ b/src/Presentation/ConfigDocumentationBuilder.php
@@ -78,7 +78,7 @@ class ConfigDocumentationBuilder {
 			'id' => $id,
 			'exists' => $exists,
 			'itemLink' => $this->getItemLink( $id, $this->labelLookup->getLabel( $itemType )?->getText() ),
-			'tabName' => $exists ? $tabNameMsg->plain() : null,
+			'tabName' => $exists ? $tabNameMsg->text() : null,
 			'actionLink' => $this->getActionLink( $id, $exists ),
 		];
 	}


### PR DESCRIPTION
For #226 

Before:
![Screenshot_20250308_122022](https://github.com/user-attachments/assets/40a77a79-8331-47e7-bc26-94eb893fef86)

After:
![Screenshot_20250308_122007](https://github.com/user-attachments/assets/9dc25009-dea9-445e-b50d-9d93ca660b77)
