### PR TITLE
Update minimum MW version to 1.43

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -16,7 +16,7 @@
 	"type": "wikibase",
 
 	"requires": {
-		"MediaWiki": ">= 1.39.0",
+		"MediaWiki": ">= 1.43.0",
 		"extensions": {
 			"WikibaseRepository": "*",
 			"CirrusSearch": "*",


### PR DESCRIPTION
The extension is targeted for 1.43 instead of 1.39