### PR TITLE
Use Node 22 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Setup NPM dependencies
         run: npm install
@@ -247,7 +247,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Setup NPM dependencies
         run: npm install

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ stan-baseline:
 # Commands run from the host machine #######################################################################
 
 npm-install:
-	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:20 npm install
+	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:22 npm install
 
 lint:
-	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:20 npm run lint
+	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:22 npm run lint
 
 jest:
-	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:20 npm run test:unit
+	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:22 npm run test:unit
 
 js: lint jest


### PR DESCRIPTION
We should switch to Node 22 since it is the current latest LTS