### PR TITLE
Remove WikibaseCirrusSearch dependency

### DIFF
--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -31,9 +31,6 @@ wfLoadExtension( 'CirrusSearch' );
 wfLoadExtension( 'WikibaseRepository', __DIR__ . '/extensions/Wikibase/extension-repo.json' );
 require_once __DIR__ . '/extensions/Wikibase/repo/ExampleSettings.php';
 
-wfLoadExtension( 'WikibaseCirrusSearch' );
-\$wgWBCSUseCirrus = true;
-
 wfLoadExtension( "$EXTENSION_NAME" );
 EOT
 
@@ -56,7 +53,6 @@ EOT
 cd extensions
 git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/Elastica --depth=1  --branch=$MW_BRANCH --recurse-submodules -j8
 git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/CirrusSearch --depth=1  --branch=$MW_BRANCH --recurse-submodules -j8
-git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/WikibaseCirrusSearch --depth=1  --branch=$MW_BRANCH --recurse-submodules -j8
 
 git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/Wikibase --depth=1 --branch=$MW_BRANCH -j8 && \
   cd Wikibase && \

--- a/extension.json
+++ b/extension.json
@@ -19,8 +19,7 @@
 		"MediaWiki": ">= 1.43.0",
 		"extensions": {
 			"WikibaseRepository": "*",
-			"CirrusSearch": "*",
-			"WikibaseCirrusSearch": "*"
+			"CirrusSearch": "*"
 		}
 	},
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,7 +11,6 @@ parameters:
 		- ../../vendor
 		- ../../extensions/CirrusSearch
 		- ../../extensions/Wikibase
-		- ../../extensions/WikibaseCirrusSearch
 	bootstrapFiles:
 		- ../../includes/AutoLoader.php
 	excludePaths:


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/WikibaseFacetedSearch/issues/236

WikibaseCirrusSearch was used early on when we depended on the `haswbstatement` keyword (and possibly something else). However, the code no longer depends on it, so it can be removed.