### PR TITLE
Use namespace

### DIFF
--- a/src/Persistence/SitelinkBasedStatementsLookup.php
+++ b/src/Persistence/SitelinkBasedStatementsLookup.php
@@ -23,7 +23,7 @@ class SitelinkBasedStatementsLookup implements StatementsLookup {
 	public function getStatements( WikiPage $page ): StatementList {
 		$itemId = $this->sitelinkLookup->getItemIdForLink(
 			$this->sitelinkSiteId,
-			$page->getTitle()->getText()
+			$page->getTitle()->getPrefixedText()
 		);
 
 		if ( $itemId === null ) {

--- a/src/Persistence/SitelinkPageItemLookup.php
+++ b/src/Persistence/SitelinkPageItemLookup.php
@@ -18,7 +18,7 @@ class SitelinkPageItemLookup implements PageItemLookup {
 	}
 
 	public function getItemId( Title $title ): ?ItemId {
-		return $this->sitelinkLookup->getItemIdForLink( $this->sitelinkSiteId, $title->getText() );
+		return $this->sitelinkLookup->getItemIdForLink( $this->sitelinkSiteId, $title->getPrefixedText() );
 	}
 
 }

--- a/tests/phpunit/Persistence/SitelinkBasedStatementsLookupTest.php
+++ b/tests/phpunit/Persistence/SitelinkBasedStatementsLookupTest.php
@@ -75,7 +75,7 @@ class SitelinkBasedStatementsLookupTest extends WikibaseFacetedSearchIntegration
 	}
 
 	private function createSitelink( Item $item, WikiPage $page, string $siteId = self::SITE_ID ): void {
-		$item->getSiteLinkList()->addNewSiteLink( $siteId, $page->getTitle()->getText() );
+		$item->getSiteLinkList()->addNewSiteLink( $siteId, $page->getTitle()->getPrefixedText() );
 		$this->sitelinkStore->saveLinksOfItem( $item );
 	}
 
@@ -158,6 +158,28 @@ class SitelinkBasedStatementsLookupTest extends WikibaseFacetedSearchIntegration
 			[
 				new Statement( new PropertyValueSnak( new NumericPropertyId( 'P3' ), new StringValue( 'foo' ) ) ),
 				new Statement( new PropertyValueSnak( new NumericPropertyId( 'P4' ), new StringValue( 'bar' ) ) )
+			]
+		);
+	}
+
+	public function testCustomNamespacePageWithSitelinkToItemWithStatementsReturnsStatements(): void {
+		$item = new Item(
+			id: new ItemId( 'Q1' ),
+			statements: new StatementList(
+				new Statement( new PropertyValueSnak( new NumericPropertyId( 'P1' ), new StringValue( 'foo' ) ) ),
+				new Statement( new PropertyValueSnak( new NumericPropertyId( 'P2' ), new StringValue( 'bar' ) ) )
+			)
+		);
+		$page = $this->createPage( namespace: 1337 );
+
+		$this->entityLookup->addEntity( $item );
+		$this->createSitelink( $item, $page );
+
+		$this->assertPageHasStatements(
+			$page,
+			[
+				new Statement( new PropertyValueSnak( new NumericPropertyId( 'P1' ), new StringValue( 'foo' ) ) ),
+				new Statement( new PropertyValueSnak( new NumericPropertyId( 'P2' ), new StringValue( 'bar' ) ) )
 			]
 		);
 	}

--- a/tests/phpunit/WikibaseFacetedSearchIntegrationTest.php
+++ b/tests/phpunit/WikibaseFacetedSearchIntegrationTest.php
@@ -61,8 +61,8 @@ class WikibaseFacetedSearchIntegrationTest extends MediaWikiIntegrationTestCase 
 		return $editPage->getContext()->getOutput()->getHTML();
 	}
 
-	protected function createPage( string $title = 'Test page' ): WikiPage {
-		$page = new WikiPage( Title::newFromText( $title ) );
+	protected function createPage( string $title = 'Test page', int $namespace = NS_MAIN ): WikiPage {
+		$page = new WikiPage( Title::newFromText( $title, $namespace ) );
 		$this->editPage( $page, 'Wikitext content' );
 		return $page;
 	}


### PR DESCRIPTION
For #231 

----

Elasticsearch data comparison to https://github.com/ProfessionalWiki/WikibaseFacetedSearch/issues/231#issuecomment-2726535040

`namespace` contains a value, and `title` no longer includes the namespace

```bash
curl -X GET "http://elasticsearch:9200/_search?pretty" -H "Content-Type: application/json" -d '
{
  "query": {
    "term": {
      "_id": "47"
    }
  }
}'
```
```
...
        "_index" : "mediawiki_content_first",
        "_type" : "_doc",
        "_id" : "47",
        "_score" : 1.0,
        "_source" : {
          "version" : 47,
          "wiki" : "mediawiki",
          "page_id" : 47,
          "namespace" : 4202,
          "namespace_text" : "Person",
          "title" : "62906",
          "timestamp" : "2023-12-06T12:49:42Z",
          "create_timestamp" : "2023-12-06T12:49:42Z",
          "redirect" : [ ],
          "incoming_links" : 0,
          "wbfs_P592" : [
            "Q57196"
          ],
          "wbfs_P598" : [
            "Q57229",
            "Q62432",
            "Q59697",
            "Q61708"
          ],
          "wbfs_P593" : [
            "1979-10-14T00:00:00Z"
          ],
          "wbfs_P437" : [ ],
          "wbfs_P463" : [
            140312.0
          ],
          "wbfs_P1460" : [
            "Q5976445"
          ],
...
```