### PR TITLE
Add getStatements() logging

### DIFF
--- a/src/Application/StatementListTranslator.php
+++ b/src/Application/StatementListTranslator.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\Application;
 
+use Psr\Log\LoggerInterface;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Statement\Statement;
@@ -14,7 +15,8 @@ class StatementListTranslator {
 	public function __construct(
 		private readonly StatementTranslator $statementTranslator,
 		private readonly ItemTypeExtractor $itemTypeExtractor,
-		private readonly Config $config
+		private readonly Config $config,
+		private readonly LoggerInterface $logger
 	) {
 	}
 
@@ -23,13 +25,19 @@ class StatementListTranslator {
 	 * @return array<string, mixed>
 	 */
 	public function translateStatements( StatementList $statements ): array {
+		$this->logger->debug( 'Translating statements' );
+
 		$itemType = $this->itemTypeExtractor->getItemType( $statements );
+
+		$this->logger->debug( 'itemType: ' . ( $itemType?->getSerialization() ?? 'MISSING' ) );
 
 		if ( $itemType === null ) {
 			return [];
 		}
 
 		$propertyIds = $this->getPropertiesToIndex( $itemType );
+
+		$this->logger->debug( 'propertyIds: ' . implode( ',', $propertyIds ) );
 
 		$values = [];
 

--- a/src/Persistence/SitelinkBasedStatementsLookup.php
+++ b/src/Persistence/SitelinkBasedStatementsLookup.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence;
 
 use ProfessionalWiki\WikibaseFacetedSearch\Application\StatementsLookup;
+use Psr\Log\LoggerInterface;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Services\Lookup\EntityLookup;
 use Wikibase\DataModel\Statement\StatementList;
@@ -16,15 +17,21 @@ class SitelinkBasedStatementsLookup implements StatementsLookup {
 	public function __construct(
 		private readonly string $sitelinkSiteId,
 		private readonly SiteLinkLookup $sitelinkLookup,
-		private readonly EntityLookup $entityLookup
+		private readonly EntityLookup $entityLookup,
+		private readonly LoggerInterface $logger
 	) {
 	}
 
 	public function getStatements( WikiPage $page ): StatementList {
+		$this->logger->debug( 'Getting statements for page: ' . $page->getTitle()->getPrefixedText() );
+
 		$itemId = $this->sitelinkLookup->getItemIdForLink(
 			$this->sitelinkSiteId,
 			$page->getTitle()->getPrefixedText()
 		);
+
+		$this->logger->debug( 'sitelinkSiteId: ' . $this->sitelinkSiteId );
+		$this->logger->debug( 'itemId: ' . ( $itemId?->getSerialization() ?? 'MISSING' ) );
 
 		if ( $itemId === null ) {
 			return new StatementList();
@@ -32,11 +39,17 @@ class SitelinkBasedStatementsLookup implements StatementsLookup {
 
 		$entity = $this->entityLookup->getEntity( $itemId );
 
+		$this->logger->debug( 'entity type: ' . ( $entity?->getType() ?? 'MISSING' ) );
+
 		if ( !( $entity instanceof Item ) ) {
 			return new StatementList();
 		}
 
-		return $entity->getStatements();
+		$statements = $entity->getStatements();
+
+		$this->logger->debug( 'statements count: ' . count( $statements ) );
+
+		return $statements;
 	}
 
 }

--- a/src/WikibaseFacetedSearchExtension.php
+++ b/src/WikibaseFacetedSearchExtension.php
@@ -11,6 +11,7 @@ use MediaWiki\Context\IContextSource;
 use MediaWiki\Html\TemplateParser;
 use MediaWiki\Language\Language;
 use MediaWiki\Linker\LinkRendererFactory;
+use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
@@ -61,6 +62,7 @@ use ProfessionalWiki\WikibaseFacetedSearch\Presentation\ListFacetHtmlBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\RangeFacetHtmlBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\SidebarHtmlBuilder;
 use ProfessionalWiki\WikibaseFacetedSearch\Presentation\TabsHtmlBuilder;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Wikibase\DataModel\Services\Lookup\LabelLookup;
 use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookup;
@@ -174,7 +176,8 @@ class WikibaseFacetedSearchExtension {
 		return new SitelinkBasedStatementsLookup(
 			sitelinkSiteId: $this->getConfig()->sitelinkSiteId,
 			sitelinkLookup: WikibaseRepo::getStore()->newSiteLinkStore(),
-			entityLookup: WikibaseRepo::getEntityLookup()
+			entityLookup: WikibaseRepo::getEntityLookup(),
+			logger: $this->getLogger()
 		);
 	}
 
@@ -386,6 +389,10 @@ class WikibaseFacetedSearchExtension {
 			linkRenderer: $this->getLinkRendererFactory()->create(),
 			labelLookup: $this->getLabelLookup( $context->getLanguage() )
 		);
+	}
+
+	private function getLogger(): LoggerInterface {
+		return LoggerFactory::getInstance( 'WikibaseFacetedSearch' );
 	}
 
 }

--- a/src/WikibaseFacetedSearchExtension.php
+++ b/src/WikibaseFacetedSearchExtension.php
@@ -185,7 +185,8 @@ class WikibaseFacetedSearchExtension {
 		return new StatementListTranslator(
 			statementTranslator: $this->newStatementTranslator(),
 			itemTypeExtractor: $this->newItemTypeExtractor(),
-			config: $this->getConfig()
+			config: $this->getConfig(),
+			logger: $this->getLogger()
 		);
 	}
 

--- a/tests/phpunit/Application/StatementListTranslatorTest.php
+++ b/tests/phpunit/Application/StatementListTranslatorTest.php
@@ -14,6 +14,7 @@ use ProfessionalWiki\WikibaseFacetedSearch\Application\FacetType;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\StatementListTranslator;
 use ProfessionalWiki\WikibaseFacetedSearch\Tests\TestDoubles\StubItemTypeExtractor;
 use ProfessionalWiki\WikibaseFacetedSearch\Tests\TestDoubles\StubStatementTranslator;
+use Psr\Log\NullLogger;
 use Wikibase\DataModel\Entity\EntityIdValue;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\NumericPropertyId;
@@ -35,7 +36,8 @@ class StatementListTranslatorTest extends TestCase {
 		return new StatementListTranslator(
 			$statementTranslator ?? new StubStatementTranslator(),
 			$itemTypeExtractor ?? new StubItemTypeExtractor(),
-			$config ?? new Config()
+			$config ?? new Config(),
+			new NullLogger()
 		);
 	}
 

--- a/tests/phpunit/Persistence/SitelinkBasedStatementsLookupTest.php
+++ b/tests/phpunit/Persistence/SitelinkBasedStatementsLookupTest.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Persistence;
 use DataValues\StringValue;
 use ProfessionalWiki\WikibaseFacetedSearch\Persistence\SitelinkBasedStatementsLookup;
 use ProfessionalWiki\WikibaseFacetedSearch\Tests\WikibaseFacetedSearchIntegrationTest;
+use Psr\Log\NullLogger;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\NumericPropertyId;
@@ -38,7 +39,8 @@ class SitelinkBasedStatementsLookupTest extends WikibaseFacetedSearchIntegration
 		$this->lookup = new SitelinkBasedStatementsLookup(
 			self::SITE_ID,
 			$this->sitelinkStore,
-			$this->entityLookup
+			$this->entityLookup,
+			new NullLogger()
 		);
 
 		$this->setMwGlobals( 'wgExtraNamespaces', [


### PR DESCRIPTION
For #231 

Temporary logging just to see where the code stops, so no fancy messages.

Requires something like this in LocalSettings:
```php
$wgDebugLogGroups = [
	'WikibaseFacetedSearch' => __DIR__ . '/cache/WikibaseFacetedSearch.log'
];
```

Example logs when editing a page with a sitelink:
```
2025-03-17 22:11:27 baba8b2152e0 mediawiki: Getting statements for page: Person:57520
2025-03-17 22:11:27 baba8b2152e0 mediawiki: sitelinkSiteId: mardi
2025-03-17 22:11:27 baba8b2152e0 mediawiki: itemId: Q57520
2025-03-17 22:11:27 baba8b2152e0 mediawiki: entity type: item
2025-03-17 22:11:27 baba8b2152e0 mediawiki: statements count: 36
2025-03-17 22:11:27 baba8b2152e0 mediawiki: Translating statements
2025-03-17 22:11:27 baba8b2152e0 mediawiki: itemType: Q5976445
2025-03-17 22:11:27 baba8b2152e0 mediawiki: propertyIds: P592,P598,P593,P437,P463,P1460
```

Example logs when editing a page without a sitelink:
```
2025-03-17 22:12:37 baba8b2152e0 mediawiki: Getting statements for page: Lorem Ipsum
2025-03-17 22:12:37 baba8b2152e0 mediawiki: sitelinkSiteId: mardi
2025-03-17 22:12:37 baba8b2152e0 mediawiki: itemId: MISSING
2025-03-17 22:12:37 baba8b2152e0 mediawiki: Translating statements
2025-03-17 22:12:37 baba8b2152e0 mediawiki: itemType: MISSING
```