### PR TITLE
Add max height to make facets scrollable

### DIFF
--- a/resources/ext.wikibase.facetedsearch.less
+++ b/resources/ext.wikibase.facetedsearch.less
@@ -54,6 +54,11 @@
 		position: sticky;
 		top: @spacing-100;
 
+		@media ( min-width: @min-width-breakpoint-tablet ) {
+			max-height: calc( 100vh - @spacing-100 * 2 );
+			overflow-y: auto;
+		}
+
 		@media ( max-width: @max-width-breakpoint-tablet ) {
 			display: none;
 


### PR DESCRIPTION
The bottom of the facets are unreachable when the facets element is sticky and long.
Making it scrollable will resolve the issue.