### PR TITLE
Add basic date precision handling

### DIFF
--- a/src/Application/DataValueTranslator.php
+++ b/src/Application/DataValueTranslator.php
@@ -22,7 +22,8 @@ class DataValueTranslator {
 		}
 
 		if ( $dataValue instanceof TimeValue ) {
-			return ltrim( $dataValue->getTime(), '+-' );
+			// TODO: handle date precision explicitly.
+			return str_replace( '-00', '-01', ltrim( $dataValue->getTime(), '+-' ) );
 		}
 
 		if ( $dataValue instanceof EntityIdValue ) {

--- a/tests/phpunit/Application/DataValueTranslatorTest.php
+++ b/tests/phpunit/Application/DataValueTranslatorTest.php
@@ -33,13 +33,45 @@ class DataValueTranslatorTest extends TestCase {
 		$this->assertSame( 'Foo', $this->newTranslator()->translate( $value ) );
 	}
 
-	public function testTranslatesTimeValue(): void {
+	public function testTranslatesTimeValuewithDayPrecision(): void {
 		$value = new TimeValue(
 			'+2020-01-01T00:00:00Z',
 			0,
 			0,
 			0,
 			TimeValue::PRECISION_DAY,
+			TimeValue::CALENDAR_GREGORIAN
+		);
+
+		$this->assertSame(
+			'2020-01-01T00:00:00Z',
+			$this->newTranslator()->translate( $value )
+		);
+	}
+
+	public function testTranslatesTimeValueWithMonthPrecision(): void {
+		$value = new TimeValue(
+			'+2020-01-00T00:00:00Z',
+			0,
+			0,
+			0,
+			TimeValue::PRECISION_MONTH,
+			TimeValue::CALENDAR_GREGORIAN
+		);
+
+		$this->assertSame(
+			'2020-01-01T00:00:00Z',
+			$this->newTranslator()->translate( $value )
+		);
+	}
+
+	public function testTranslatesTimeValueWithYearPrecision(): void {
+		$value = new TimeValue(
+			'+2020-00-00T00:00:00Z',
+			0,
+			0,
+			0,
+			TimeValue::PRECISION_YEAR,
 			TimeValue::CALENDAR_GREGORIAN
 		);
 


### PR DESCRIPTION
For #254 

Turns out we have to index the partial date as a valid ISO 8601 date, otherwise the date range filter ignores it.

----

Search returns:
![Screenshot_20250325_231000](https://github.com/user-attachments/assets/75fd1023-7a44-45fb-8d9d-7ce64f1774ac)

For statement:
![Screenshot_20250325_231048](https://github.com/user-attachments/assets/ff047074-c402-411e-91d6-3c0265bef9a2)

With Elastic data:
```
"wbfs_P28" : [
  "1957-01-01T00:00:00Z"
],

```