### PR TITLE
Remove specific property when counting

### DIFF
--- a/src/Application/ValueCounter.php
+++ b/src/Application/ValueCounter.php
@@ -4,10 +4,8 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\Application;
 
-use Wikibase\DataModel\Entity\PropertyId;
-
 interface ValueCounter {
 
-	public function countValues( PropertyId $property, PropertyConstraints $constraints ): ValueCounts;
+	public function countValues( PropertyConstraints $constraints ): ValueCounts;
 
 }

--- a/src/Application/ValueCounter.php
+++ b/src/Application/ValueCounter.php
@@ -8,6 +8,6 @@ use Wikibase\DataModel\Entity\PropertyId;
 
 interface ValueCounter {
 
-	public function countValues( PropertyId $property ): ValueCounts;
+	public function countValues( PropertyId $property, PropertyConstraints $constraints ): ValueCounts;
 
 }

--- a/src/EntryPoints/WikibaseFacetedSearchHooks.php
+++ b/src/EntryPoints/WikibaseFacetedSearchHooks.php
@@ -116,18 +116,11 @@ class WikibaseFacetedSearchHooks {
 			WikibaseFacetedSearchExtension::getInstance()
 				->getSidebarHtmlBuilder(
 					language: $specialSearch->getLanguage(),
-					currentQuery: self::getFilteredCurrentQuery( $term )
+					currentQuery: self::getCurrentQuery()
 				)
 				->createHtml(
 					searchQuery: $term
 				)
-		);
-	}
-
-	private static function getFilteredCurrentQuery( string $searchQuery ): AbstractQuery {
-		return WikibaseFacetedSearchExtension::getInstance()->newElasticQueryFilter()->removeOrFacets(
-			self::getCurrentQuery(),
-			WikibaseFacetedSearchExtension::getInstance()->getQueryStringParser()->parse( $searchQuery )
 		);
 	}
 

--- a/src/Persistence/ElasticValueCounter.php
+++ b/src/Persistence/ElasticValueCounter.php
@@ -5,6 +5,8 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseFacetedSearch\Persistence;
 
 use Elastica\Query\AbstractQuery;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\ElasticQueryFilter;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraints;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ValueCount;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ValueCounter;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ValueCounts;
@@ -14,7 +16,8 @@ class ElasticValueCounter implements ValueCounter {
 
 	public function __construct(
 		private readonly ElasticQueryRunner $queryRunner,
-		private readonly AbstractQuery $currentQuery
+		private readonly AbstractQuery $currentQuery,
+		private readonly ElasticQueryFilter $queryFilter,
 	) {
 	}
 
@@ -22,10 +25,10 @@ class ElasticValueCounter implements ValueCounter {
 	 * Count the values for a given property, highest occurrences first.
 	 * Values are indexed per property at wbfs_P123, where P123 is the serialization of the property id.
 	 */
-	public function countValues( PropertyId $property ): ValueCounts {
+	public function countValues( PropertyId $property, PropertyConstraints $constraints ): ValueCounts {
 		$query = [
 			'size' => 0,
-			'query' => $this->currentQuery->toArray(),
+			'query' => $this->getFilteredQuery( $property, $constraints )->toArray(),
 			'aggs' => [
 				'valueCounts' => [
 					'terms' => [
@@ -53,6 +56,13 @@ class ElasticValueCounter implements ValueCounter {
 		}
 
 		return new ValueCounts( $valueCounts );
+	}
+
+	private function getFilteredQuery( PropertyId $property, PropertyConstraints $constraints ): AbstractQuery {
+		if ( $constraints->getOrSelectedValues() !== [] ) {
+			return $this->queryFilter->removeFacet( $this->currentQuery, $property );
+		}
+		return $this->currentQuery;
 	}
 
 }

--- a/src/Persistence/ElasticValueCounter.php
+++ b/src/Persistence/ElasticValueCounter.php
@@ -25,14 +25,14 @@ class ElasticValueCounter implements ValueCounter {
 	 * Count the values for a given property, highest occurrences first.
 	 * Values are indexed per property at wbfs_P123, where P123 is the serialization of the property id.
 	 */
-	public function countValues( PropertyId $property, PropertyConstraints $constraints ): ValueCounts {
+	public function countValues( PropertyConstraints $constraints ): ValueCounts {
 		$query = [
 			'size' => 0,
-			'query' => $this->getFilteredQuery( $property, $constraints )->toArray(),
+			'query' => $this->getFilteredQuery( $constraints )->toArray(),
 			'aggs' => [
 				'valueCounts' => [
 					'terms' => [
-						'field' => 'wbfs_' . $property->getSerialization(),
+						'field' => 'wbfs_' . $constraints->propertyId->getSerialization(),
 						'size' => 100,
 					],
 				],
@@ -58,9 +58,9 @@ class ElasticValueCounter implements ValueCounter {
 		return new ValueCounts( $valueCounts );
 	}
 
-	private function getFilteredQuery( PropertyId $property, PropertyConstraints $constraints ): AbstractQuery {
+	private function getFilteredQuery( PropertyConstraints $constraints ): AbstractQuery {
 		if ( $constraints->getOrSelectedValues() !== [] ) {
-			return $this->queryFilter->removeFacet( $this->currentQuery, $property );
+			return $this->queryFilter->removeFacet( $this->currentQuery, $constraints->propertyId );
 		}
 		return $this->currentQuery;
 	}

--- a/src/Presentation/ListFacetHtmlBuilder.php
+++ b/src/Presentation/ListFacetHtmlBuilder.php
@@ -31,7 +31,7 @@ class ListFacetHtmlBuilder implements FacetHtmlBuilder {
 	}
 
 	public function buildHtml( FacetConfig $config, PropertyConstraints $state ): string {
-		$valueCounts = $this->getValuesAndCounts( $config, $state );
+		$valueCounts = $this->getValuesAndCounts( $state );
 		if ( count( $valueCounts ) === 0 ) {
 			return '';
 		}
@@ -149,8 +149,8 @@ class ListFacetHtmlBuilder implements FacetHtmlBuilder {
 	/**
 	 * @return ValueCount[]
 	 */
-	public function getValuesAndCounts( FacetConfig $config, PropertyConstraints $state ): array {
-		return $this->valueCounter->countValues( $config->propertyId, $state )->asArray();
+	public function getValuesAndCounts( PropertyConstraints $state ): array {
+		return $this->valueCounter->countValues( $state )->asArray();
 	}
 
 }

--- a/src/Presentation/ListFacetHtmlBuilder.php
+++ b/src/Presentation/ListFacetHtmlBuilder.php
@@ -31,7 +31,7 @@ class ListFacetHtmlBuilder implements FacetHtmlBuilder {
 	}
 
 	public function buildHtml( FacetConfig $config, PropertyConstraints $state ): string {
-		$valueCounts = $this->getValuesAndCounts( $config );
+		$valueCounts = $this->getValuesAndCounts( $config, $state );
 		if ( count( $valueCounts ) === 0 ) {
 			return '';
 		}
@@ -149,8 +149,8 @@ class ListFacetHtmlBuilder implements FacetHtmlBuilder {
 	/**
 	 * @return ValueCount[]
 	 */
-	public function getValuesAndCounts( FacetConfig $config ): array {
-		return $this->valueCounter->countValues( $config->propertyId )->asArray();
+	public function getValuesAndCounts( FacetConfig $config, PropertyConstraints $state ): array {
+		return $this->valueCounter->countValues( $config->propertyId, $state )->asArray();
 	}
 
 }

--- a/src/WikibaseFacetedSearchExtension.php
+++ b/src/WikibaseFacetedSearchExtension.php
@@ -258,7 +258,8 @@ class WikibaseFacetedSearchExtension {
 	public function getValueCounter( AbstractQuery $currentQuery ): ValueCounter {
 		return new ElasticValueCounter(
 			queryRunner: $this->getElasticQueryRunner(),
-			currentQuery: $currentQuery
+			currentQuery: $currentQuery,
+			queryFilter: new ElasticQueryFilter(),
 		);
 	}
 

--- a/tests/phpunit/Persistence/ElasticValueCounterTest.php
+++ b/tests/phpunit/Persistence/ElasticValueCounterTest.php
@@ -17,9 +17,8 @@ use Wikibase\DataModel\Entity\NumericPropertyId;
 class ElasticValueCounterTest extends TestCase {
 
 	public function testCanExecuteValueCountQuery(): void {
-		$propertyId = new NumericPropertyId( 'P22' );
 		$counter = WikibaseFacetedSearchExtension::getInstance()->getValueCounter( new MatchAll() );
-		$counter->countValues( $propertyId, new PropertyConstraints( $propertyId ) );
+		$counter->countValues( new PropertyConstraints( new NumericPropertyId( 'P22' ) ) );
 		$this->assertTrue( true );
 	}
 

--- a/tests/phpunit/Persistence/ElasticValueCounterTest.php
+++ b/tests/phpunit/Persistence/ElasticValueCounterTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\Persistence;
 
 use Elastica\Query\MatchAll;
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraints;
 use ProfessionalWiki\WikibaseFacetedSearch\WikibaseFacetedSearchExtension;
 use Wikibase\DataModel\Entity\NumericPropertyId;
 
@@ -16,8 +17,9 @@ use Wikibase\DataModel\Entity\NumericPropertyId;
 class ElasticValueCounterTest extends TestCase {
 
 	public function testCanExecuteValueCountQuery(): void {
+		$propertyId = new NumericPropertyId( 'P22' );
 		$counter = WikibaseFacetedSearchExtension::getInstance()->getValueCounter( new MatchAll() );
-		$counter->countValues( new NumericPropertyId( 'P22' ) );
+		$counter->countValues( $propertyId, new PropertyConstraints( $propertyId ) );
 		$this->assertTrue( true );
 	}
 

--- a/tests/phpunit/Presentation/ListFacetHtmlBuilderTest.php
+++ b/tests/phpunit/Presentation/ListFacetHtmlBuilderTest.php
@@ -112,11 +112,12 @@ class ListFacetHtmlBuilderTest extends TestCase {
 	): array {
 		$htmlBuilder = $this->newListFacetHtmlBuilder( $valueCounter );
 		$facetConfig = $this->newFacetConfig( $typeSpecificConfig );
+		$state = $constraints ?? $this->newPropertyConstraints();
 
 		return $htmlBuilder->buildViewModel(
 			config: $facetConfig,
-			state: $constraints ?? $this->newPropertyConstraints(),
-			valueCounts: $htmlBuilder->getValuesAndCounts( $facetConfig )
+			state: $state,
+			valueCounts: $htmlBuilder->getValuesAndCounts( $facetConfig, $state )
 		);
 	}
 

--- a/tests/phpunit/Presentation/ListFacetHtmlBuilderTest.php
+++ b/tests/phpunit/Presentation/ListFacetHtmlBuilderTest.php
@@ -117,7 +117,7 @@ class ListFacetHtmlBuilderTest extends TestCase {
 		return $htmlBuilder->buildViewModel(
 			config: $facetConfig,
 			state: $state,
-			valueCounts: $htmlBuilder->getValuesAndCounts( $facetConfig, $state )
+			valueCounts: $htmlBuilder->getValuesAndCounts( $state )
 		);
 	}
 

--- a/tests/phpunit/TestDoubles/SequentialValueCounter.php
+++ b/tests/phpunit/TestDoubles/SequentialValueCounter.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\TestDoubles;
 
+use ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraints;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ValueCount;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ValueCounter;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ValueCounts;
@@ -16,7 +17,7 @@ class SequentialValueCounter implements ValueCounter {
 	) {
 	}
 
-	public function countValues( PropertyId $property ): ValueCounts {
+	public function countValues( PropertyId $property, PropertyConstraints $constraints ): ValueCounts {
 		if ( $this->count === 0 ) {
 			return new ValueCounts( [] );
 		}

--- a/tests/phpunit/TestDoubles/SequentialValueCounter.php
+++ b/tests/phpunit/TestDoubles/SequentialValueCounter.php
@@ -8,7 +8,6 @@ use ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraints;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ValueCount;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ValueCounter;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ValueCounts;
-use Wikibase\DataModel\Entity\PropertyId;
 
 class SequentialValueCounter implements ValueCounter {
 
@@ -17,7 +16,7 @@ class SequentialValueCounter implements ValueCounter {
 	) {
 	}
 
-	public function countValues( PropertyId $property, PropertyConstraints $constraints ): ValueCounts {
+	public function countValues( PropertyConstraints $constraints ): ValueCounts {
 		if ( $this->count === 0 ) {
 			return new ValueCounts( [] );
 		}

--- a/tests/phpunit/TestDoubles/StubValueCounter.php
+++ b/tests/phpunit/TestDoubles/StubValueCounter.php
@@ -33,7 +33,7 @@ class StubValueCounter implements ValueCounter {
 	public const SEVENTH_VALUE = 'Grace';
 	public const SEVENTH_COUNT = 3;
 
-	public function countValues( PropertyId $property, PropertyConstraints $constraints ): ValueCounts {
+	public function countValues( PropertyConstraints $constraints ): ValueCounts {
 		return new ValueCounts( [
 			new ValueCount( self::FIRST_VALUE, self::FIRST_COUNT ),
 			new ValueCount( self::SECOND_VALUE, self::SECOND_COUNT ),

--- a/tests/phpunit/TestDoubles/StubValueCounter.php
+++ b/tests/phpunit/TestDoubles/StubValueCounter.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\TestDoubles;
 
+use ProfessionalWiki\WikibaseFacetedSearch\Application\PropertyConstraints;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ValueCount;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ValueCounter;
 use ProfessionalWiki\WikibaseFacetedSearch\Application\ValueCounts;
@@ -32,7 +33,7 @@ class StubValueCounter implements ValueCounter {
 	public const SEVENTH_VALUE = 'Grace';
 	public const SEVENTH_COUNT = 3;
 
-	public function countValues( PropertyId $property ): ValueCounts {
+	public function countValues( PropertyId $property, PropertyConstraints $constraints ): ValueCounts {
 		return new ValueCounts( [
 			new ValueCount( self::FIRST_VALUE, self::FIRST_COUNT ),
 			new ValueCount( self::SECOND_VALUE, self::SECOND_COUNT ),


### PR DESCRIPTION
For #258 

Previous problem: It removed _all_ OR queries from the current query.
Solution: Remove the OR query only when getting counts for the specific facet. 

[Screencast_20250330_135332.webm](https://github.com/user-attachments/assets/bcc2d3cb-02e1-4167-9a20-43bc927dedd2)
