### PR TITLE
Do not build sidebar when current query is missing

### DIFF
--- a/src/EntryPoints/WikibaseFacetedSearchHooks.php
+++ b/src/EntryPoints/WikibaseFacetedSearchHooks.php
@@ -112,20 +112,23 @@ class WikibaseFacetedSearchHooks {
 			return;
 		}
 
-		$output->addHTML(
-			WikibaseFacetedSearchExtension::getInstance()
-				->getSidebarHtmlBuilder(
-					language: $specialSearch->getLanguage(),
-					currentQuery: self::getCurrentQuery()
-				)
-				->createHtml(
-					searchQuery: $term
-				)
-		);
+		$currentQuery = self::getCurrentQuery();
+		if ( $currentQuery !== null ) {
+			$output->addHTML(
+				WikibaseFacetedSearchExtension::getInstance()
+					->getSidebarHtmlBuilder(
+						language: $specialSearch->getLanguage(),
+						currentQuery: $currentQuery
+					)
+					->createHtml(
+						searchQuery: $term
+					)
+			);
+		}
 	}
 
-	private static function getCurrentQuery(): AbstractQuery {
-		return $GLOBALS[WikibaseFacetedSearchExtension::QUERY_GLOBAL];
+	private static function getCurrentQuery(): ?AbstractQuery {
+		return $GLOBALS[WikibaseFacetedSearchExtension::QUERY_GLOBAL] ?? null;
 	}
 
 	public static function onContentHandlerDefaultModelFor( Title $title, ?string &$model ): void {


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/WikibaseFacetedSearch/issues/266

When the query fails (for whatever reason unrelated to WikibaseFacetedSearch), then it still tried to build the sidebar with the missing query obejct.

This change just skips sidebar building when the current query is missing.