### PR TITLE
Support external-id and edtf property types for faceted search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,34 +16,40 @@ jobs:
             php: '8.1'
             experimental: false
             coverage: false
+            search-image: 'docker-registry.wikimedia.org/repos/search-platform/cirrussearch-elasticsearch-image:v7.10.2-12'
           - mw: 'REL1_43'
             php: '8.2'
             experimental: false
             coverage: true
+            search-image: 'docker-registry.wikimedia.org/repos/search-platform/cirrussearch-elasticsearch-image:v7.10.2-12'
           - mw: 'REL1_44'
             php: '8.3'
             experimental: false
             coverage: false
+            search-image: 'docker-registry.wikimedia.org/repos/search-platform/cirrussearch-elasticsearch-image:v7.10.2-12'
           - mw: 'REL1_45'
             php: '8.4'
             experimental: false
             coverage: false
+            search-image: 'docker-registry.wikimedia.org/repos/search-platform/cirrussearch-elasticsearch-image:v7.10.2-12'
           - mw: 'master'
             php: '8.5'
-            experimental: true
+            experimental: false
             coverage: false
+            search-image: 'docker-registry.wikimedia.org/repos/search-platform/cirrussearch-opensearch-image:v1.3.20-12'
 
     runs-on: ubuntu-latest
 
     services:
       elasticsearch:
-        image: docker-registry.wikimedia.org/releng/cirrus-elasticsearch:7.10.2-s0 # Compatibility info at https://www.mediawiki.org/wiki/Extension:CirrusSearch
+        image: ${{ matrix.search-image }}
         ports:
           - 9200:9200
           - 9300:9300
         env:
           discovery.type: single-node
           ES_JAVA_OPTS: "-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
+          OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
 
     defaults:
       run:
@@ -65,7 +71,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v2
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v3
 
       - name: Cache Composer cache
         uses: actions/cache@v4
@@ -101,11 +107,21 @@ jobs:
           php maintenance/runJobs.php
 
       - name: Run PHPUnit
-        run: php tests/phpunit/phpunit.php -c extensions/WikibaseFacetedSearch/
+        run: |
+          if [ -f tests/phpunit/phpunit.php ]; then
+            php tests/phpunit/phpunit.php -c extensions/WikibaseFacetedSearch/
+          else
+            composer phpunit -- extensions/WikibaseFacetedSearch/tests/
+          fi
         if: ${{ ! matrix.coverage }}
 
       - name: Run PHPUnit with code coverage
-        run: php tests/phpunit/phpunit.php -c extensions/WikibaseFacetedSearch/ --coverage-clover coverage.xml
+        run: |
+          if [ -f tests/phpunit/phpunit.php ]; then
+            php tests/phpunit/phpunit.php -c extensions/WikibaseFacetedSearch/ --coverage-clover coverage.xml
+          else
+            composer phpunit -- extensions/WikibaseFacetedSearch/tests/ --coverage-clover coverage.xml
+          fi
         if: ${{ matrix.coverage }}
 
       - name: Upload code coverage
@@ -145,7 +161,7 @@ jobs:
             mediawiki
             mediawiki/extensions/
             mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v2
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v3
 
       - name: Cache Composer cache
         uses: actions/cache@v4
@@ -214,7 +230,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.composer/cache
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v2
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v3
 
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -12,6 +12,12 @@ mv mediawiki-$MW_BRANCH mediawiki
 
 cd mediawiki
 
+# phpunit.xml.template is excluded from GitHub tarballs via .gitattributes export-ignore.
+# Download it directly from the repo if missing.
+if [ ! -f phpunit.xml.template ]; then
+    wget "https://raw.githubusercontent.com/wikimedia/mediawiki/$MW_BRANCH/phpunit.xml.template" -nv -O phpunit.xml.template 2>/dev/null || true
+fi
+
 composer install
 php maintenance/install.php --dbtype sqlite --dbuser root --dbname mw --dbpath $(pwd) --pass AdminPassword WikiName AdminUser
 

--- a/src/Persistence/PageContentFetcher.php
+++ b/src/Persistence/PageContentFetcher.php
@@ -8,6 +8,7 @@ use Content;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\Revision\SlotRecord;
 use MediaWiki\Title\MalformedTitleException;
+use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleParser;
 
 class PageContentFetcher {
@@ -20,7 +21,7 @@ class PageContentFetcher {
 
 	public function getPageContent( string $pageTitle ): ?Content {
 		try {
-			$title = $this->titleParser->parseTitle( $pageTitle );
+			$title = Title::newFromLinkTarget( $this->titleParser->parseTitle( $pageTitle ) );
 		} catch ( MalformedTitleException ) {
 			return null;
 		}

--- a/src/Persistence/Search/Query/ListFacetQueryBuilder.php
+++ b/src/Persistence/Search/Query/ListFacetQueryBuilder.php
@@ -36,7 +36,7 @@ class ListFacetQueryBuilder implements FacetQueryBuilder {
 		}
 
 		return match ( $this->dataTypeLookup->getDataTypeIdForProperty( $config->propertyId ) ) {
-			'string' => $this->buildStringQuery( $name, $values ),
+			'string', 'external-id', 'edtf' => $this->buildStringQuery( $name, $values ),
 			'wikibase-item' => $this->buildStringQuery( $name, $values ),
 			'quantity' => $this->buildQuantityQuery( $name, $values ),
 			'time' => $this->buildTimeQuery( $name, $values ),

--- a/src/Persistence/Search/SearchIndexFieldsBuilder.php
+++ b/src/Persistence/Search/SearchIndexFieldsBuilder.php
@@ -53,7 +53,7 @@ class SearchIndexFieldsBuilder {
 	private function getFieldTypeForDataTypeId( string $dataTypeId ): ?string {
 		return match ( $dataTypeId ) {
 			'quantity' => SearchIndexField::INDEX_TYPE_NUMBER,
-			'string' => SearchIndexField::INDEX_TYPE_KEYWORD,
+			'string', 'external-id', 'edtf' => SearchIndexField::INDEX_TYPE_KEYWORD,
 			'time' => SearchIndexField::INDEX_TYPE_DATETIME,
 			'wikibase-item' => SearchIndexField::INDEX_TYPE_KEYWORD,
 			default => null

--- a/tests/phpunit/EntryPoints/SpecialWikibaseFacetedSearchConfigTest.php
+++ b/tests/phpunit/EntryPoints/SpecialWikibaseFacetedSearchConfigTest.php
@@ -4,28 +4,22 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseFacetedSearch\Tests\EntryPoints;
 
-use MediaWiki\SpecialPage\SpecialPage;
 use MediaWiki\Title\Title;
 use ProfessionalWiki\WikibaseFacetedSearch\WikibaseFacetedSearchExtension;
-use SpecialPageTestBase;
 
 /**
  * @covers \ProfessionalWiki\WikibaseFacetedSearch\EntryPoints\SpecialWikibaseFacetedSearchConfig
  */
-class SpecialWikibaseFacetedSearchConfigTest extends SpecialPageTestBase {
-
-	protected function newSpecialPage(): SpecialPage {
-		return $this->getServiceContainer()->getSpecialPageFactory()->getPage( 'WikibaseFacetedSearchConfig' );
-	}
+class SpecialWikibaseFacetedSearchConfigTest extends \MediaWikiIntegrationTestCase {
 
 	public function testRedirect(): void {
-		$specialRules = $this->newSpecialPage();
+		$specialPage = $this->getServiceContainer()->getSpecialPageFactory()->getPage( 'WikibaseFacetedSearchConfig' );
 
-		$specialRules->execute( null );
+		$specialPage->execute( null );
 
 		$this->assertEquals(
 			Title::newFromText( WikibaseFacetedSearchExtension::CONFIG_PAGE_TITLE, NS_MEDIAWIKI )->getFullURL(),
-			$specialRules->getOutput()->getRedirect()
+			$specialPage->getOutput()->getRedirect()
 		);
 	}
 

--- a/tests/phpunit/Persistence/Search/Query/ListFacetQueryBuilderTest.php
+++ b/tests/phpunit/Persistence/Search/Query/ListFacetQueryBuilderTest.php
@@ -25,6 +25,8 @@ class ListFacetQueryBuilderTest extends TestCase {
 	private const STRING_PROPERTY = 'P200';
 	private const TIME_PROPERTY = 'P300';
 	private const ITEM_PROPERTY = 'P400';
+	private const EXTERNAL_ID_PROPERTY = 'P500';
+	private const EDTF_PROPERTY = 'P600';
 
 	public function testBuildsQueryForStringList(): void {
 		$query = $this->newFacetQueryBuilder()->buildQuery(
@@ -55,7 +57,9 @@ class ListFacetQueryBuilderTest extends TestCase {
 			self::QUANTITY_PROPERTY => 'quantity',
 			self::STRING_PROPERTY => 'string',
 			self::TIME_PROPERTY => 'time',
-			self::ITEM_PROPERTY => 'wikibase-item'
+			self::ITEM_PROPERTY => 'wikibase-item',
+			self::EXTERNAL_ID_PROPERTY => 'external-id',
+			self::EDTF_PROPERTY => 'edtf'
 		];
 
 		foreach ( $types as $pId => $type ) {
@@ -166,6 +170,38 @@ class ListFacetQueryBuilderTest extends TestCase {
 				'field' => 'wbfs_' . self::STRING_PROPERTY
 			],
 			$query->getParams()
+		);
+	}
+
+	public function testBuildsQueryForExternalIdList(): void {
+		$query = $this->newFacetQueryBuilder()->buildQuery(
+			$this->newListFacetConfig( self::EXTERNAL_ID_PROPERTY ),
+			new PropertyConstraints(
+				new NumericPropertyId( self::EXTERNAL_ID_PROPERTY ),
+				orSelectedValues: [ 'ID-001', 'ID-002' ]
+			)
+		);
+
+		$this->assertIsTermsQueryWithParams(
+			self::EXTERNAL_ID_PROPERTY,
+			[ 'ID-001', 'ID-002' ],
+			$query
+		);
+	}
+
+	public function testBuildsQueryForEdtfList(): void {
+		$query = $this->newFacetQueryBuilder()->buildQuery(
+			$this->newListFacetConfig( self::EDTF_PROPERTY ),
+			new PropertyConstraints(
+				new NumericPropertyId( self::EDTF_PROPERTY ),
+				orSelectedValues: [ '1850', '1920-03-15' ]
+			)
+		);
+
+		$this->assertIsTermsQueryWithParams(
+			self::EDTF_PROPERTY,
+			[ '1850', '1920-03-15' ],
+			$query
 		);
 	}
 

--- a/tests/phpunit/Persistence/Search/SearchIndexFieldsBuilderTest.php
+++ b/tests/phpunit/Persistence/Search/SearchIndexFieldsBuilderTest.php
@@ -66,7 +66,9 @@ class SearchIndexFieldsBuilderTest extends TestCase {
 			'P100' => 'quantity',
 			'P200' => 'string',
 			'P300' => 'time',
-			'P400' => 'wikibase-item'
+			'P400' => 'wikibase-item',
+			'P500' => 'external-id',
+			'P600' => 'edtf'
 		];
 
 		foreach ( $types as $pId => $type ) {
@@ -130,6 +132,42 @@ class SearchIndexFieldsBuilderTest extends TestCase {
 
 	private function newProperty( string $id, string $dataType ): Property {
 		return new Property( new NumericPropertyId( $id ), null, $dataType );
+	}
+
+	public function testCreatesKeywordFieldForExternalIdProperty(): void {
+		$builder = $this->newBuilder(
+			new Config(
+				itemTypeProperty: new NumericPropertyId( 'P1' ),
+				facets: new FacetConfigList(
+					$this->newFacetConfig( 'Q1', 'P500' )
+				)
+			)
+		);
+
+		$fields = $builder->createFieldObjects();
+
+		$this->assertEquals(
+			new AggregatableKeywordIndexField( 'wbfs_P500', SearchIndexField::INDEX_TYPE_KEYWORD, $this->cirrusSearch->getConfig() ),
+			$fields['wbfs_P500']
+		);
+	}
+
+	public function testCreatesKeywordFieldForEdtfProperty(): void {
+		$builder = $this->newBuilder(
+			new Config(
+				itemTypeProperty: new NumericPropertyId( 'P1' ),
+				facets: new FacetConfigList(
+					$this->newFacetConfig( 'Q1', 'P600' )
+				)
+			)
+		);
+
+		$fields = $builder->createFieldObjects();
+
+		$this->assertEquals(
+			new AggregatableKeywordIndexField( 'wbfs_P600', SearchIndexField::INDEX_TYPE_KEYWORD, $this->cirrusSearch->getConfig() ),
+			$fields['wbfs_P600']
+		);
 	}
 
 	public function testDoesNotReturnFieldsForMissingProperties(): void {

--- a/tests/phpunit/Persistence/SitelinkBasedStatementsLookupTest.php
+++ b/tests/phpunit/Persistence/SitelinkBasedStatementsLookupTest.php
@@ -33,6 +33,8 @@ class SitelinkBasedStatementsLookupTest extends WikibaseFacetedSearchIntegration
 	private SitelinkBasedStatementsLookup $lookup;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->sitelinkStore = new HashSiteLinkStore();
 		$this->entityLookup = new InMemoryEntityLookup();
 		$this->lookup = new SitelinkBasedStatementsLookup(

--- a/tests/phpunit/WikibaseFacetedSearchIntegrationTest.php
+++ b/tests/phpunit/WikibaseFacetedSearchIntegrationTest.php
@@ -33,7 +33,9 @@ class WikibaseFacetedSearchIntegrationTest extends MediaWikiIntegrationTestCase 
 		 */
 		$title = Title::newFromText( 'MediaWiki:' . WikibaseFacetedSearchExtension::CONFIG_PAGE_TITLE );
 
-		$this->deletePage( new WikiPage( $title ) );
+		if ( $title->exists() ) {
+			$this->deletePage( new WikiPage( $title ) );
+		}
 	}
 
 	protected function getPageHtml( string $pageTitle ): string {


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/WikibaseFacetedSearch/issues/276

## Summary

**Faceted search fix:** Both `external-id` and `edtf` properties use `StringValue` internally, so
the `DataValueTranslator` already handles their values. The missing piece was that these datatype IDs
were not included in the match statements of `SearchIndexFieldsBuilder` and `ListFacetQueryBuilder`,
causing their facets to be silently ignored. Range facets for EDTF are not yet supported (follow-up).

**CI fix:** Update CI for MW master compatibility — use OpenSearch 1.3 instead of deprecated
Elasticsearch 7.10, handle removal of `tests/phpunit/phpunit.php`, download `phpunit.xml.template`
excluded from tarballs, and stop using removed `SpecialPageTestBase`. MW master remains experimental
due to upstream deprecation warnings in `RevisionStore`.
