### PR TITLE
Allow `psr/log` versions ^2.0 and ^3.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"composer/installers": "^2|^1.0.1",
 		"opis/json-schema": "^2.3.0",
 		"ruflin/elastica": "^7.1.0",
-		"psr/log": "^1.1.4",
+		"psr/log": "^1.1.4 || ^2.0 || ^3.0",
 		"professional-wiki/message-builder": "^1.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Otherwise, composer complains about version conflicts
when installed from MW root dir and extension is
included via merge-plugin.

```json
{
	"extra": {
		"merge-plugin": {
			"include": [
				"extensions/*/composer.json",
				"skins/*/composer.json"
			]
		}
	}
}
```
