### PR TITLE
Fix CI for MW master: tolerate absent Wikibase JS submodules

### DIFF
--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -60,9 +60,15 @@ cd extensions
 git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/Elastica --depth=1  --branch=$MW_BRANCH --recurse-submodules -j8
 git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/CirrusSearch --depth=1  --branch=$MW_BRANCH --recurse-submodules -j8
 
-git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/Wikibase --depth=1 --branch=$MW_BRANCH -j8 && \
-  cd Wikibase && \
-  git submodule set-url view/lib/wikibase-serialization https://github.com/wmde/WikibaseSerializationJavaScript.git && \
-  git submodule set-url view/lib/wikibase-data-values https://github.com/wmde/DataValuesJavaScript.git && \
-  git submodule set-url view/lib/wikibase-data-model https://github.com/wmde/WikibaseDataModelJavaScript.git && \
-  git submodule sync && git submodule init && git submodule update --recursive
+git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/Wikibase --depth=1 --branch=$MW_BRANCH -j8
+cd Wikibase
+
+# The wikibase-serialization, wikibase-data-values and wikibase-data-model submodules point at
+# Phabricator URLs that are unreliable in CI, so rewrite them to GitHub mirrors. These submodules
+# only exist on the REL branches; MediaWiki master removed them (migrated to npm), so skip silently
+# when absent instead of aborting the build.
+git submodule set-url view/lib/wikibase-serialization https://github.com/wmde/WikibaseSerializationJavaScript.git 2>/dev/null || true
+git submodule set-url view/lib/wikibase-data-values https://github.com/wmde/DataValuesJavaScript.git 2>/dev/null || true
+git submodule set-url view/lib/wikibase-data-model https://github.com/wmde/WikibaseDataModelJavaScript.git 2>/dev/null || true
+
+git submodule sync && git submodule init && git submodule update --recursive


### PR DESCRIPTION
_Written by Claude Code, Opus 4.8 (1M context). @JeroenDeDauw spotted that CI fails for the MW master matrix job and asked for a simple fix. Context: the WikibaseFacetedSearch codebase, its CI workflow and failing run logs, and Wikibase's `.gitmodules` on `master` vs the `REL1_*` branches._

The MW master CI job aborted in `installMediaWiki.sh` with exit 128:

```
fatal: no submodule mapping found in .gitmodules for path 'view/lib/wikibase-serialization'
```

Wikibase master removed the `wikibase-serialization`, `wikibase-data-values` and `wikibase-data-model` view-layer submodules (migrated to npm), so `git submodule set-url` on those paths fails. Under `set -e` this aborted the install before PHPUnit ran, and fail-fast then cancelled every other matrix job.

These JS libraries are not needed by the PHP test suite. Make the URL rewrites tolerant of an absent submodule so the script no longer aborts on master, while behaviour on REL1_43/44/45 (where the submodules still exist) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)