### PR TITLE
Release 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Commands that use Docker:
 
 ## Release Notes
 
+### Version 1.1.0 - 2026-06-15
+
+* Added support for the external identifier property type to list facets
+* Added support for the EDTF property type to list facets (range facets are not yet supported)
+* Added support for MediaWiki 1.45
+* Added support for PHP 8.5
+* Updated translations
+
 ### Version 1.0.1 - 2025-12-05
 
 * Updated translations

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
 	"name": "Wikibase Faceted Search",
 
-	"version": "1.0.1",
+	"version": "1.1.0",
 
 	"author": [
 		"[https://Professional.Wiki/ Professional Wiki]"


### PR DESCRIPTION
_Written by Claude Code, Opus 4.8 (1M context). Prepared at @JeroenDeDauw's request after merging the MW-master CI fix (#283) and the psr/log fix (#282). Context: the WikibaseFacetedSearch repo — `git log 1.0.1..master`, `extension.json`, and the README "Release Notes" section._

Prepares the 1.1.0 release: bumps `extension.json` to `1.1.0` and adds the README release-notes entry.

### Version 1.1.0 - 2026-06-15

* Added support for the external identifier property type to list facets
* Added support for the EDTF property type to list facets (range facets are not yet supported)
* Added support for MediaWiki 1.45
* Added support for PHP 8.5
* Updated translations

Minor bump (new property-type support is a feature). CI/dev-tooling commits since 1.0.1 are intentionally omitted from the user-facing notes.

Tagging and publishing the signed `1.1.0` tag is left to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)